### PR TITLE
mlx feature参照の削除とCIジョブ統合

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,37 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-candle:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-        with:
-          toolchain: stable
-          components: clippy, rustfmt
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
-
-      - name: Check
-        run: cargo check --no-default-features --features candle
-
-      - name: Test
-        run: cargo test --no-default-features --features candle
-
-      - name: Clippy
-        run: cargo clippy --no-default-features --features candle -- -D warnings
-
-      - name: Format check
-        run: cargo fmt -- --check
-
-  test-mlx:
+  test:
     runs-on: macos-latest
     timeout-minutes: 15
     permissions:
@@ -60,13 +30,13 @@ jobs:
         uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
       - name: Check
-        run: cargo check --no-default-features --features mlx
+        run: cargo check
 
       - name: Test
-        run: cargo test --no-default-features --features mlx
+        run: cargo test
 
       - name: Clippy
-        run: cargo clippy --no-default-features --features mlx -- -D warnings
+        run: cargo clippy -- -D warnings
 
       - name: Format check
         run: cargo fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,11 +1991,12 @@ dependencies = [
 
 [[package]]
 name = "rurico"
-version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=56320e3#56320e30f0c9c639ece68ecd292338a853820cd6"
+version = "0.2.0"
+source = "git+https://github.com/thkt/rurico?rev=cd4f2ad#cd4f2ad796e4814ae15dd50063813356718b4a88"
 dependencies = [
  "bytemuck",
  "hf-hub",
+ "log",
  "mlx-rs",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,22 +7,20 @@ license = "MIT"
 repository = "https://github.com/thkt/recall"
 
 [features]
-default = ["mlx"]
-mlx = ["rurico/mlx"]
 test-support = ["rurico/test-support"]
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 dirs = "6"
-rurico = { git = "https://github.com/thkt/rurico", rev = "56320e3" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "cd4f2ad" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "56320e3", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "cd4f2ad", features = ["test-support"] }
 serial_test = "3"
 tempfile = "3"
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use rusqlite::Connection;
 use rurico::embed::EMBEDDING_DIMS;
+use rusqlite::Connection;
 
 const FTS_TOKENIZER: &str = "trigram";
 

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use rusqlite::Connection;
 use rurico::embed::Embed;
 #[cfg(test)]
-use rurico::embed::{EmbedError, EMBEDDING_DIMS};
+use rurico::embed::{EMBEDDING_DIMS, EmbedError};
+use rusqlite::Connection;
 
 #[derive(Default)]
 pub(crate) struct EmbedResult {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1058,8 +1058,7 @@ mod tests {
         );
 
         let embedder = MockEmbedder::failing_after(EMBED_BATCH_SIZE);
-        let result =
-            embed_recent_chunks(&mut conn, &embedder, chunk_count as usize, None).unwrap();
+        let result = embed_recent_chunks(&mut conn, &embedder, chunk_count as usize, None).unwrap();
 
         assert_eq!(
             result.embedded, EMBED_BATCH_SIZE,

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,9 +4,9 @@ use anyhow::{Context, Result};
 use rusqlite::Connection;
 
 use crate::date::MS_PER_DAY;
-use rurico::embed::Embed;
 use crate::hybrid;
 use crate::parser::{SessionData, Source};
+use rurico::embed::Embed;
 
 const RECENCY_BOOST_WEIGHT: f64 = 0.2;
 


### PR DESCRIPTION
## 概要

Closes #11

- rurico v0.2.0で`mlx` featureが廃止されたため、`Cargo.toml`から`mlx` Cargo featureと`rurico/mlx`依存を削除
- rurico revを`56320e3`から`cd4f2ad`に更新（`[dependencies]`と`[dev-dependencies]`の両方）
- CIの2ジョブ構成（`test-candle` on ubuntu-latest + `test-mlx` on macos-latest）を、macos-latestの単一`test`ジョブに統合

## テスト計画

- [ ] CI `test`ジョブがmacos-latestで`cargo check`, `cargo test`, `cargo clippy`, `cargo fmt --check`を通過する
- [ ] `Cargo.toml`と`ci.yml`に`mlx` feature参照が残っていないこと
- [ ] 更新後のrurico revで`cargo build`がローカルで成功すること