### PR TITLE
rurico を bc2ad90 に更新し ChunkedEmbedding API へ移行

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
+source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
+source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,18 +2005,28 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=dd1ad45#dd1ad45c6007c3e1114034a435eef8424f977e48"
+source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
 dependencies = [
  "bytemuck",
  "hf-hub",
  "log",
  "mlx-rs",
+ "rurico-ffi",
  "rusqlite",
  "serde",
  "serde_json",
- "sqlite-vec",
  "thiserror",
  "tokenizers",
+]
+
+[[package]]
+name = "rurico-ffi"
+version = "0.1.0"
+source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
+dependencies = [
+ "mlx-sys",
+ "rusqlite",
+ "sqlite-vec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "recall"
 version = "0.7.0"
 edition = "2024"
+rust-version = "1.95"
 description = "Full-text search CLI for past Claude Code and Codex sessions"
 license = "MIT"
 repository = "https://github.com/thkt/recall"
@@ -14,14 +15,14 @@ anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 dirs = "6.0.0"
 hex = "0.4.3"
-rurico = { git = "https://github.com/thkt/rurico", rev = "dd1ad45" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526" }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "dd1ad45", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526", features = ["test-support"] }
 serial_test = "3"
 tempfile = "3"
 
@@ -29,21 +30,21 @@ tempfile = "3"
 unsafe_code = "deny"
 
 [lints.clippy]
-# フルパス使用検出
+# absolute paths
 absolute_paths = "deny"
-# Rustイディオム (RUST.md idioms table)
+# idiomatic iterators
 cast_possible_truncation = "deny"
 redundant_closure_for_method_calls = "deny"
 filter_map_next = "deny"
 flat_map_option = "deny"
 manual_filter_map = "deny"
 manual_find_map = "deny"
-# インポート
+# imports
 wildcard_imports = "deny"
 enum_glob_use = "deny"
-# 文字列
+# strings
 str_to_string = "deny"
-# 引数
+# arguments
 needless_pass_by_value = "deny"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 dirs = "6.0.0"
 hex = "0.4.3"
-rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90", features = ["test-support"] }
 serial_test = "3"
 tempfile = "3"
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -32,6 +32,7 @@ fn create_schema(conn: &mut Connection) -> Result<()> {
     )?;
 
     migrate_fts_if_needed(conn)?;
+    migrate_vec_chunks_if_needed(conn)?;
 
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project);
@@ -70,14 +71,54 @@ fn create_schema(conn: &mut Connection) -> Result<()> {
 
     conn.execute_batch(&format!(
         "CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(
-            chunk_id INTEGER PRIMARY KEY,
-            embedding FLOAT[{EMBEDDING_DIMS}]
+            embedding FLOAT[{EMBEDDING_DIMS}],
+            +chunk_id INTEGER,
+            +sub_idx INTEGER
         );"
     ))?;
 
     conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS embedded_chunk_ids (
+            chunk_id INTEGER NOT NULL,
+            sub_idx INTEGER NOT NULL,
+            vec_rowid INTEGER NOT NULL,
+            PRIMARY KEY (chunk_id, sub_idx)
+        );
+        CREATE INDEX IF NOT EXISTS idx_embedded_chunk_ids_chunk ON embedded_chunk_ids(chunk_id);",
+    )?;
+
+    conn.execute_batch(
         "CREATE VIRTUAL TABLE IF NOT EXISTS messages_vocab USING fts5vocab(messages, row);",
     )?;
+
+    Ok(())
+}
+
+fn migrate_vec_chunks_if_needed(conn: &mut Connection) -> Result<()> {
+    let sql: Option<String> = match conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='vec_chunks'",
+        [],
+        |r| r.get(0),
+    ) {
+        Ok(sql) => Some(sql),
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(e) => return Err(e.into()),
+    };
+
+    let Some(sql) = sql else {
+        return Ok(());
+    };
+
+    if !sql.contains("sub_idx") {
+        eprintln!(
+            "recall: Embedding schema changed — clearing embeddings (re-run `recall index --embed` to rebuild)"
+        );
+        let tx = conn.transaction()?;
+        tx.execute_batch(
+            "DROP TABLE IF EXISTS vec_chunks; DROP TABLE IF EXISTS embedded_chunk_ids;",
+        )?;
+        tx.commit()?;
+    }
 
     Ok(())
 }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use anyhow::Result;
 use rurico::embed::Embed;
 #[cfg(test)]
-use rurico::embed::{EMBEDDING_DIMS, EmbedError};
+use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS, EmbedError};
 use rurico::storage::f32_as_bytes;
 use rusqlite::Connection;
 use rusqlite::types::ToSql;
@@ -48,12 +48,21 @@ fn embed_chunks(
         match embedder.embed_documents_batch(&texts) {
             Ok(embeddings) => {
                 let tx = conn.transaction()?;
-                for (embedding, &i) in embeddings.iter().zip(batch_idx) {
-                    let embedding_bytes = f32_as_bytes(embedding);
-                    tx.execute(
-                        "INSERT INTO vec_chunks (chunk_id, embedding) VALUES (?1, ?2)",
-                        rusqlite::params![chunks[i].0, embedding_bytes],
-                    )?;
+                for (chunked, &i) in embeddings.iter().zip(batch_idx) {
+                    for (sub_idx, sub_emb) in chunked.chunks.iter().enumerate() {
+                        let embedding_bytes = f32_as_bytes(sub_emb);
+                        tx.execute(
+                            "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) \
+                             VALUES (?1, ?2, ?3)",
+                            rusqlite::params![embedding_bytes, chunks[i].0, sub_idx as i64],
+                        )?;
+                        let vec_rowid = tx.last_insert_rowid();
+                        tx.execute(
+                            "INSERT INTO embedded_chunk_ids (chunk_id, sub_idx, vec_rowid) \
+                             VALUES (?1, ?2, ?3)",
+                            rusqlite::params![chunks[i].0, sub_idx as i64, vec_rowid],
+                        )?;
+                    }
                 }
                 tx.commit()?;
                 embedded += embeddings.len();
@@ -171,7 +180,7 @@ impl MockEmbedder {
     }
 
     pub(crate) fn deterministic_vector(text: &str) -> Vec<f32> {
-        let dims = EMBEDDING_DIMS as usize;
+        let dims = EMBEDDING_DIMS;
         let mut v = vec![0.0f32; dims];
         for (i, b) in text.bytes().enumerate() {
             v[i % dims] += b as f32;
@@ -189,16 +198,28 @@ impl MockEmbedder {
 #[cfg(test)]
 impl Embed for MockEmbedder {
     fn embed_query(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
-        self.embed_document(text)
-    }
-
-    fn embed_document(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
         if let Some(limit) = self.fail_after {
             let count = self.call_count.fetch_add(1, Ordering::SeqCst);
             if count >= limit {
                 return Err(EmbedError::Inference("mock failure".to_owned()));
             }
         }
+        Ok(Self::deterministic_vector(text))
+    }
+
+    fn embed_document(&self, text: &str) -> Result<ChunkedEmbedding, EmbedError> {
+        if let Some(limit) = self.fail_after {
+            let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+            if count >= limit {
+                return Err(EmbedError::Inference("mock failure".to_owned()));
+            }
+        }
+        Ok(ChunkedEmbedding {
+            chunks: vec![Self::deterministic_vector(text)],
+        })
+    }
+
+    fn embed_text(&self, text: &str, _prefix: &str) -> Result<Vec<f32>, EmbedError> {
         Ok(Self::deterministic_vector(text))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use std::process;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use rurico::embed::{Embed, Embedder, download_model};
+use rurico::embed::{Embed, Embedder, ModelId, download_model};
 use rusqlite::Connection;
 
 use crate::parser::Source;
@@ -132,7 +132,7 @@ fn resolve_db_path(db_path: &Option<PathBuf>) -> Result<PathBuf> {
 }
 
 fn try_load_embedder() -> Option<Embedder> {
-    let paths = match download_model() {
+    let paths = match download_model(ModelId::default()) {
         Ok(p) => p,
         Err(e) => {
             eprintln!("Warning: model download failed: {e}");
@@ -178,8 +178,8 @@ fn run_index(force: bool, embed: bool, verbose: bool, db_path: &Option<PathBuf>)
 
     if embed {
         let sp = progress::Spinner::new("Loading model...");
-        let paths =
-            download_model().map_err(|e| anyhow::anyhow!("Failed to download model: {e}"))?;
+        let paths = download_model(ModelId::default())
+            .map_err(|e| anyhow::anyhow!("Failed to download model: {e}"))?;
         let embedder =
             Embedder::new(&paths).map_err(|e| anyhow::anyhow!("Failed to load model: {e}"))?;
         sp.finish("Model ready");
@@ -206,7 +206,7 @@ fn run_index(force: bool, embed: bool, verbose: bool, db_path: &Option<PathBuf>)
             progress::done("All chunks already embedded");
         }
     } else {
-        let model_cached = download_model().is_ok();
+        let model_cached = download_model(ModelId::default()).is_ok();
         eprintln!(
             "  Model: {}",
             if model_cached {
@@ -405,7 +405,7 @@ fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
     println!("QA chunks: {chunks}");
     println!("Embedded: {embedded}/{chunks}");
 
-    let model_ok = download_model().is_ok();
+    let model_ok = download_model(ModelId::default()).is_ok();
     println!(
         "Model: {}",
         if model_ok {


### PR DESCRIPTION
## 概要

- `rust-version = "1.95"` を固定し、rurico を `bc2ad90` へ bump（rurico#37 で rurico-ffi も MSRV 1.95）。
- rurico の新しい `Embed` trait に追随 — `embed_document` が `ChunkedEmbedding` を返し、`download_model` は `ModelId` を必須化。
- `vec_chunks` を `(embedding, +chunk_id, +sub_idx)` に再構成し、`embedded_chunk_ids` を新設（sae と同レイアウト）。
- 既存 `.recall.db` は起動時に embedding テーブルを DROP するワンショットマイグレーションが走る。

## 経緯

`5663e7c` はこのブランチで rurico を `0de6526` へ bump したが、その rev に既に入っていた API 変更に追随していなかった。具体的には `Embed::embed_document` の戻り値が `Vec<f32>` から `ChunkedEmbedding` に変わり、`download_model` が `ModelId` を要求するようになっていた。`5663e7c` 単体に対する `cargo check` は `src/embedder.rs` と `src/main.rs` で 5 件のエラーで失敗する。

`8e20840` は rurico をさらに `bc2ad90` へ進める（rurico-ffi MSRV 1.95）。`4861f82` が本体の API 移行で、`ChunkedEmbedding.chunks` を展開して各 sub-embedding を `sub_idx` 付きで永続化、`download_model` の呼び出し 4 箇所に `ModelId::default()` を渡し、`MockEmbedder` に新規 trait メソッド `embed_text` を実装する。

## スキーママイグレーション

**既存 `.recall.db` は次回起動時に embedding が消える。** `vec_chunks` は `(chunk_id PRIMARY KEY, embedding)` から `(embedding, +chunk_id, +sub_idx)` へ変わり、`embedded_chunk_ids (chunk_id, sub_idx, vec_rowid)` が新設される。`open_db` が `sqlite_master` で旧レイアウトを検出し、トランザクション内で両テーブルを DROP してから再作成する。FTS データとパース済みセッションはそのまま残る。利用者は `recall index --embed` でベクトルを再生成する。

新レイアウトは sae の `storage::embed` モジュールと揃うので、将来 embedding 関連コードを共通化しやすくなる。

## 検証

| チェック       | コマンド                                        | 結果               |
| -------------- | ----------------------------------------------- | ------------------ |
| fmt            | `cargo fmt --check`                             | pass               |
| clippy         | `cargo clippy --all-targets -- -D warnings`     | pass               |
| tests          | `cargo test --bin recall`                       | 107 pass / 0 fail  |
| release build  | `cargo build --release`                         | pass               |

## テスト手順

- [ ] ブランチを pull して `cargo test --bin recall` を実行し 107 件すべて pass すること。
- [ ] `cargo clippy --all-targets -- -D warnings` に警告がないこと。
- [ ] 旧ビルドで作成した `.recall.db` を開き、起動メッセージが `recall index --embed` の再実行を促し、`vec_chunks` / `embedded_chunk_ids` が新スキーマで作成されていること。
- [ ] 移行後の DB で `recall index --embed` を実行し、両テーブルに行が挿入されること。
- [ ] 再インデックス済みの DB に対し `recall search` でハイブリッド検索の結果が返ること。
