### PR TITLE
refactor: 内部整合性パターンを統一 (scout #18/#28)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -142,7 +142,7 @@ fn migrate_fts_if_needed(conn: &mut Connection) -> Result<()> {
         let session_count: i64 =
             conn.query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))?;
         eprintln!(
-            "recall: Index schema changed — rebuilding {session_count} sessions (source files are unaffected)"
+            "recall: Index schema changed — clearing {session_count} cached sessions (run `recall index` to rebuild; source files are unaffected)"
         );
         let tx = conn.transaction()?;
         tx.execute_batch(

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -556,10 +556,11 @@ pub(crate) fn index_chunks(conn: &mut Connection, verbose: bool) -> Result<Chunk
             let mut msgs = Vec::new();
             for r in rows {
                 let (role_str, text) = r?;
-                let role = match role_str.as_str() {
-                    "user" => Role::User,
-                    "assistant" => Role::Assistant,
-                    _ => continue,
+                let Some(role) = Role::from_db(&role_str) else {
+                    if verbose {
+                        eprintln!("Warning: unknown role '{role_str}' in session {session_id}");
+                    }
+                    continue;
                 };
                 msgs.push(Message { role, text });
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -54,6 +54,14 @@ impl Role {
             Role::Assistant => "assistant",
         }
     }
+
+    pub fn from_db(s: &str) -> Option<Role> {
+        match s {
+            "user" => Some(Role::User),
+            "assistant" => Some(Role::Assistant),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -413,5 +421,18 @@ mod tests {
         let off_ms =
             parse_iso_timestamp(&Value::String("2026-03-01T12:00:00.500+09:00".into())).unwrap();
         assert_eq!(utc_ms - off_ms, 9 * 3_600_000);
+    }
+
+    #[test]
+    fn test_role_from_db_known_values() {
+        assert_eq!(Role::from_db("user"), Some(Role::User));
+        assert_eq!(Role::from_db("assistant"), Some(Role::Assistant));
+    }
+
+    #[test]
+    fn test_role_from_db_unknown_returns_none() {
+        assert_eq!(Role::from_db("system"), None);
+        assert_eq!(Role::from_db(""), None);
+        assert_eq!(Role::from_db("USER"), None);
     }
 }


### PR DESCRIPTION
## 概要

- `fix(db)`: FTSマイグレーション後のメッセージを `migrate_vec_chunks_if_needed` のパターンに統一し、`recall index` 実行案内を追加 (#18)
- `refactor(parser)`: `Role::from_db` を `Source::from_db` と対称な設計で追加し、不明ロール時に verbose 警告を出すよう変更 (#28)

## 背景

どちらも refactor-scout で検出された「似たパターンの片側だけ抜けてる」構図の修正:

### #18 — マイグレーション後の案内欠落

`migrate_fts_if_needed` は FTS tokenizer 変更検出時にキャッシュを全クリアするが、続く `recall index` 実行案内がなかった。隣の `migrate_vec_chunks_if_needed` は `run \`recall embed\` to rebuild` と案内済みなので、フォーマットとトーンを揃えた。

### #28 — `Role::from_db` 欠落

`Source::from_db` は DB 由来の不明値を `None` で返し呼び出し側で警告を出す設計だが、`Role` にはそれに相当するメソッドがなく、`indexer.rs` のインライン match が `_ => continue` で無警告スキップしていた。`Role::from_db` を追加し、呼び出し側で verbose 時に `Warning: unknown role '{role_str}' in session {session_id}` を出すよう変更。

## テスト計画

- [x] `cargo test` — 109 passed (Role::from_db のテスト 2 件追加)
- [x] `cargo clippy --all-targets -- -D warnings` — warnings なし
- [x] `cargo fmt --check` — 差分なし

## フォローアップ

sae/yomu との横断的な整合と amici 抽出は別 Issue で追跡する:

- amici: `migration::notify_schema_change` + `logging::init_subscriber` 抽出
- recall: `tracing` 導入 + amici 経由化
- sae/yomu: amici 経由化

Closes #18
Closes #28