### PR TITLE
tracing 導入と amici::cli 経由化（CLI UI 整理含む）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,11 +34,12 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=880d244#880d2441b9e90c1754d75e883c0718ff99a7480d"
+source = "git+https://github.com/thkt/amici?rev=ae6ed39#ae6ed39f7a845ebd1aef40e9f126cc2c5dc5e308"
 dependencies = [
  "rurico",
  "rusqlite",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1297,6 +1298,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1402,15 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1542,6 +1558,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1895,6 +1920,8 @@ dependencies = [
  "serial_test",
  "sha2",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2273,6 +2300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,6 +2514,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2717,6 +2762,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2847,6 +2922,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/thkt/recall"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "880d244" }
+amici = { git = "https://github.com/thkt/amici", rev = "ae6ed39" }
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 dirs = "6.0.0"
@@ -21,6 +21,8 @@ rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90", features = ["test-support"] }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::time::Duration;
 
+use amici::migration::notify_schema_change;
 use anyhow::Result;
 use rurico::embed::EMBEDDING_DIMS;
 use rurico::storage::ensure_sqlite_vec;
@@ -110,9 +111,7 @@ fn migrate_vec_chunks_if_needed(conn: &mut Connection) -> Result<()> {
     };
 
     if !sql.contains("sub_idx") {
-        eprintln!(
-            "recall: Embedding schema changed — clearing embeddings (run `recall embed` to rebuild)"
-        );
+        notify_schema_change("recall", "embeddings", 0, "recall embed");
         let tx = conn.transaction()?;
         tx.execute_batch(
             "DROP TABLE IF EXISTS vec_chunks; DROP TABLE IF EXISTS embedded_chunk_ids;",
@@ -141,9 +140,8 @@ fn migrate_fts_if_needed(conn: &mut Connection) -> Result<()> {
     if !sql.contains(FTS_TOKENIZER) {
         let session_count: i64 =
             conn.query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))?;
-        eprintln!(
-            "recall: Index schema changed — clearing {session_count} cached sessions (run `recall index` to rebuild; source files are unaffected)"
-        );
+        let count = usize::try_from(session_count).unwrap_or(0);
+        notify_schema_change("recall", "cached sessions", count, "recall index");
         let tx = conn.transaction()?;
         tx.execute_batch(
             "DROP TABLE messages; DELETE FROM sessions; \

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -10,6 +10,7 @@ use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS, EmbedError};
 use rurico::storage::f32_as_bytes;
 use rusqlite::Connection;
 use rusqlite::types::ToSql;
+use tracing::warn;
 
 #[derive(Default)]
 pub(crate) struct EmbedResult {
@@ -20,7 +21,7 @@ pub(crate) struct EmbedResult {
 impl EmbedResult {
     pub(crate) fn warn_if_stopped(&self) {
         if let Some(ref err) = self.stopped_at_error {
-            eprintln!("Warning: embedding stopped early: {err}");
+            warn!(error = %err, "embedding stopped early");
         }
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -7,7 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use rusqlite::{Connection, Transaction};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::chunker;
 use crate::parser::{
@@ -53,21 +53,21 @@ fn resolve_mtime(fpath: &Path) -> Mtime {
     let meta = match fs::metadata(fpath) {
         Ok(m) => m,
         Err(_) => {
-            warn!(path = %fpath.display(), "cannot stat");
+            debug!(path = %fpath.display(), "cannot stat");
             return Mtime::Inaccessible;
         }
     };
     let mtime = match meta.modified() {
         Ok(t) => t,
         Err(e) => {
-            warn!(path = %fpath.display(), error = %e, "mtime unavailable");
+            debug!(path = %fpath.display(), error = %e, "mtime unavailable");
             return Mtime::Unknown;
         }
     };
     match mtime.duration_since(UNIX_EPOCH) {
         Ok(d) => Mtime::Value(d.as_secs_f64()),
         Err(e) => {
-            warn!(path = %fpath.display(), error = %e, "mtime before epoch");
+            debug!(path = %fpath.display(), error = %e, "mtime before epoch");
             Mtime::Unknown
         }
     }
@@ -123,7 +123,7 @@ fn upsert_session(
     )?;
 
     if parsed.skipped_lines > 0 {
-        warn!(
+        debug!(
             skipped_lines = parsed.skipped_lines,
             path = fpath_str,
             "skipped lines during parse"
@@ -148,7 +148,7 @@ fn check_freshness(ctx: &IndexContext, fpath: &Path) -> Option<(String, Option<f
     let fpath_str = match fpath.to_str() {
         Some(s) => s.to_owned(),
         None => {
-            warn!(path = %fpath.display(), "skipping non-UTF-8 path");
+            debug!(path = %fpath.display(), "skipping non-UTF-8 path");
             return None;
         }
     };
@@ -183,7 +183,7 @@ fn index_file(ctx: &IndexContext, fpath: &Path, source: &Source) -> Result<Index
         Ok(Some(p)) => p,
         Ok(None) => return Ok(IndexOutcome::Unchanged),
         Err(e) => {
-            warn!(path = %fpath.display(), error = %e, "parse failed");
+            info!(path = %fpath.display(), error = %e, "parse failed");
             return Ok(IndexOutcome::ParseError(format!(
                 "{}: {e}",
                 fpath.display()
@@ -451,7 +451,7 @@ fn collect_jsonl_files_inner(
     depth: usize,
 ) {
     if depth >= MAX_DIR_DEPTH {
-        warn!(
+        debug!(
             max_depth = MAX_DIR_DEPTH,
             path = %dir.display(),
             "depth limit reached"
@@ -481,7 +481,7 @@ fn collect_jsonl_files_inner(
             }
         };
         if ft.is_symlink() {
-            warn!(path = %entry.path().display(), "skipping symlink");
+            debug!(path = %entry.path().display(), "skipping symlink");
             continue;
         }
         let path = entry.path();
@@ -529,7 +529,7 @@ pub(crate) fn index_chunks(conn: &mut Connection) -> Result<ChunkStats> {
             for r in rows {
                 let (role_str, text) = r?;
                 let Some(role) = Role::from_db(&role_str) else {
-                    warn!(role = %role_str, session_id, "unknown role");
+                    debug!(role = %role_str, session_id, "unknown role");
                     continue;
                 };
                 msgs.push(Message { role, text });

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -7,6 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use rusqlite::{Connection, Transaction};
+use tracing::{info, warn};
 
 use crate::chunker;
 use crate::parser::{
@@ -32,12 +33,10 @@ enum IndexOutcome {
 struct IndexContext<'a> {
     tx: &'a Transaction<'a>,
     existing: &'a HashMap<String, SessionEntry>,
-    verbose: bool,
 }
 
 pub(crate) struct IndexOptions<'a> {
     pub force: bool,
-    pub verbose: bool,
     pub claude_dir: &'a Path,
     pub codex_dir: &'a Path,
 }
@@ -50,31 +49,25 @@ enum Mtime {
     Inaccessible,
 }
 
-fn resolve_mtime(fpath: &Path, verbose: bool) -> Mtime {
+fn resolve_mtime(fpath: &Path) -> Mtime {
     let meta = match fs::metadata(fpath) {
         Ok(m) => m,
         Err(_) => {
-            if verbose {
-                eprintln!("Warning: cannot stat {}", fpath.display());
-            }
+            warn!(path = %fpath.display(), "cannot stat");
             return Mtime::Inaccessible;
         }
     };
     let mtime = match meta.modified() {
         Ok(t) => t,
         Err(e) => {
-            if verbose {
-                eprintln!("Warning: mtime unavailable for {}: {e}", fpath.display());
-            }
+            warn!(path = %fpath.display(), error = %e, "mtime unavailable");
             return Mtime::Unknown;
         }
     };
     match mtime.duration_since(UNIX_EPOCH) {
         Ok(d) => Mtime::Value(d.as_secs_f64()),
         Err(e) => {
-            if verbose {
-                eprintln!("Warning: mtime before epoch for {}: {e}", fpath.display());
-            }
+            warn!(path = %fpath.display(), error = %e, "mtime before epoch");
             Mtime::Unknown
         }
     }
@@ -129,10 +122,11 @@ fn upsert_session(
         ],
     )?;
 
-    if ctx.verbose && parsed.skipped_lines > 0 {
-        eprintln!(
-            "Warning: {} skipped lines in {}",
-            parsed.skipped_lines, fpath_str
+    if parsed.skipped_lines > 0 {
+        warn!(
+            skipped_lines = parsed.skipped_lines,
+            path = fpath_str,
+            "skipped lines during parse"
         );
     }
 
@@ -154,14 +148,12 @@ fn check_freshness(ctx: &IndexContext, fpath: &Path) -> Option<(String, Option<f
     let fpath_str = match fpath.to_str() {
         Some(s) => s.to_owned(),
         None => {
-            if ctx.verbose {
-                eprintln!("Warning: skipping non-UTF-8 path: {}", fpath.display());
-            }
+            warn!(path = %fpath.display(), "skipping non-UTF-8 path");
             return None;
         }
     };
 
-    let mtime = match resolve_mtime(fpath, ctx.verbose) {
+    let mtime = match resolve_mtime(fpath) {
         Mtime::Value(v) => Some(v),
         Mtime::Unknown => None,
         Mtime::Inaccessible => return None,
@@ -191,9 +183,7 @@ fn index_file(ctx: &IndexContext, fpath: &Path, source: &Source) -> Result<Index
         Ok(Some(p)) => p,
         Ok(None) => return Ok(IndexOutcome::Unchanged),
         Err(e) => {
-            if ctx.verbose {
-                eprintln!("Warning: {}: {e}", fpath.display());
-            }
+            warn!(path = %fpath.display(), error = %e, "parse failed");
             return Ok(IndexOutcome::ParseError(format!(
                 "{}: {e}",
                 fpath.display()
@@ -216,7 +206,7 @@ pub(crate) fn resolve_claude_dir(home: &Path) -> PathBuf {
     home.join(".claude").join("projects")
 }
 
-pub fn index_sessions(conn: &mut Connection, force: bool, verbose: bool) -> Result<IndexStats> {
+pub fn index_sessions(conn: &mut Connection, force: bool) -> Result<IndexStats> {
     let home = dirs::home_dir().context("Could not determine home directory")?;
     let claude_dir = resolve_claude_dir(&home);
     let codex_dir = env::var_os("RECALL_CODEX_DIR")
@@ -226,7 +216,6 @@ pub fn index_sessions(conn: &mut Connection, force: bool, verbose: bool) -> Resu
         conn,
         &IndexOptions {
             force,
-            verbose,
             claude_dir: &claude_dir,
             codex_dir: &codex_dir,
         },
@@ -236,10 +225,10 @@ pub fn index_sessions(conn: &mut Connection, force: bool, verbose: bool) -> Resu
 fn collect_sources(opts: &IndexOptions) -> Vec<(PathBuf, Source)> {
     let mut sources = Vec::new();
     if opts.claude_dir.is_dir() {
-        collect_jsonl_files(opts.claude_dir, &mut sources, Source::Claude, opts.verbose);
+        collect_jsonl_files(opts.claude_dir, &mut sources, Source::Claude);
     }
     if opts.codex_dir.is_dir() {
-        collect_jsonl_files(opts.codex_dir, &mut sources, Source::Codex, opts.verbose);
+        collect_jsonl_files(opts.codex_dir, &mut sources, Source::Codex);
     }
     sources
 }
@@ -362,9 +351,7 @@ pub(crate) fn index_from_dirs(conn: &mut Connection, opts: &IndexOptions) -> Res
     };
     let sources = collect_sources(opts);
 
-    if opts.verbose {
-        eprintln!("Found {} source files", sources.len());
-    }
+    info!(count = sources.len(), "Found source files");
 
     let tx = conn.transaction().context("Failed to begin transaction")?;
     if opts.force {
@@ -381,7 +368,6 @@ pub(crate) fn index_from_dirs(conn: &mut Connection, opts: &IndexOptions) -> Res
     let ctx = IndexContext {
         tx: &tx,
         existing: &existing,
-        verbose: opts.verbose,
     };
     let (indexed, parse_errors, first_error) = index_all(&ctx, &sources)?;
     cleanup_orphans(&tx, &existing, &sources, indexed)?;
@@ -399,7 +385,7 @@ pub(crate) fn index_from_dirs(conn: &mut Connection, opts: &IndexOptions) -> Res
         .unwrap_or_default()
         .as_secs_f64();
     if let Err(e) = set_last_scan(conn, &key, now_secs) {
-        eprintln!("Warning: failed to save scan timestamp: {e}");
+        warn!(error = %e, "failed to save scan timestamp");
     }
 
     Ok(IndexStats {
@@ -454,13 +440,8 @@ fn cleanup_orphans(
 
 const MAX_DIR_DEPTH: usize = 10;
 
-fn collect_jsonl_files(
-    dir: &Path,
-    out: &mut Vec<(PathBuf, Source)>,
-    source: Source,
-    verbose: bool,
-) {
-    collect_jsonl_files_inner(dir, out, source, 0, verbose);
+fn collect_jsonl_files(dir: &Path, out: &mut Vec<(PathBuf, Source)>, source: Source) {
+    collect_jsonl_files_inner(dir, out, source, 0);
 }
 
 fn collect_jsonl_files_inner(
@@ -468,21 +449,19 @@ fn collect_jsonl_files_inner(
     out: &mut Vec<(PathBuf, Source)>,
     source: Source,
     depth: usize,
-    verbose: bool,
 ) {
     if depth >= MAX_DIR_DEPTH {
-        if verbose {
-            eprintln!(
-                "Warning: depth limit ({MAX_DIR_DEPTH}) reached at {}",
-                dir.display()
-            );
-        }
+        warn!(
+            max_depth = MAX_DIR_DEPTH,
+            path = %dir.display(),
+            "depth limit reached"
+        );
         return;
     }
     let entries = match fs::read_dir(dir) {
         Ok(e) => e,
         Err(e) => {
-            eprintln!("Warning: cannot read {}: {e}", dir.display());
+            warn!(path = %dir.display(), error = %e, "cannot read dir");
             return;
         }
     };
@@ -490,29 +469,24 @@ fn collect_jsonl_files_inner(
         let entry = match entry {
             Ok(e) => e,
             Err(e) => {
-                eprintln!("Warning: cannot read entry in {}: {e}", dir.display());
+                warn!(path = %dir.display(), error = %e, "cannot read entry");
                 continue;
             }
         };
         let ft = match entry.file_type() {
             Ok(ft) => ft,
             Err(e) => {
-                eprintln!(
-                    "Warning: cannot get file type for {}: {e}",
-                    entry.path().display()
-                );
+                warn!(path = %entry.path().display(), error = %e, "cannot get file type");
                 continue;
             }
         };
         if ft.is_symlink() {
-            if verbose {
-                eprintln!("Warning: skipping symlink {}", entry.path().display());
-            }
+            warn!(path = %entry.path().display(), "skipping symlink");
             continue;
         }
         let path = entry.path();
         if ft.is_dir() {
-            collect_jsonl_files_inner(&path, out, source, depth + 1, verbose);
+            collect_jsonl_files_inner(&path, out, source, depth + 1);
         } else if path.extension().is_some_and(|ext| ext == "jsonl") {
             out.push((path, source));
         }
@@ -523,7 +497,7 @@ pub(crate) struct ChunkStats {
     pub chunks_created: usize,
 }
 
-pub(crate) fn index_chunks(conn: &mut Connection, verbose: bool) -> Result<ChunkStats> {
+pub(crate) fn index_chunks(conn: &mut Connection) -> Result<ChunkStats> {
     let sessions: Vec<(String, Option<i64>)> = {
         let mut stmt = conn.prepare(
             "SELECT s.session_id, s.timestamp FROM sessions s \
@@ -539,9 +513,7 @@ pub(crate) fn index_chunks(conn: &mut Connection, verbose: bool) -> Result<Chunk
         return Ok(ChunkStats { chunks_created: 0 });
     }
 
-    if verbose {
-        eprintln!("Chunking {} sessions", sessions.len());
-    }
+    info!(count = sessions.len(), "Chunking sessions");
 
     let tx = conn.transaction()?;
     let mut chunks_created = 0;
@@ -557,9 +529,7 @@ pub(crate) fn index_chunks(conn: &mut Connection, verbose: bool) -> Result<Chunk
             for r in rows {
                 let (role_str, text) = r?;
                 let Some(role) = Role::from_db(&role_str) else {
-                    if verbose {
-                        eprintln!("Warning: unknown role '{role_str}' in session {session_id}");
-                    }
+                    warn!(role = %role_str, session_id, "unknown role");
                     continue;
                 };
                 msgs.push(Message { role, text });
@@ -621,7 +591,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
@@ -634,7 +603,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
@@ -662,7 +630,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
@@ -671,7 +638,7 @@ mod tests {
         assert_eq!(stats.indexed, 1);
 
         // Populate qa_chunks + vec_chunks before force reindex
-        index_chunks(&mut conn, false).unwrap();
+        index_chunks(&mut conn).unwrap();
         let embedder = MockEmbedder::new();
         embed_recent_chunks(&mut conn, &embedder, 100, None).unwrap();
         let qa_before: i64 = conn
@@ -690,7 +657,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: true,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
@@ -726,7 +692,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
@@ -736,7 +701,7 @@ mod tests {
         assert_eq!(stats.total_sessions, 2);
 
         // Create chunks + embeddings for session2 before deleting the file
-        index_chunks(&mut conn, false).unwrap();
+        index_chunks(&mut conn).unwrap();
         let embedder = MockEmbedder::new();
         embed_recent_chunks(&mut conn, &embedder, 100, None).unwrap();
         let chunks_before: i64 = conn
@@ -762,7 +727,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
@@ -816,7 +780,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &dir_a,
                 codex_dir: &empty_dir,
             },
@@ -828,7 +791,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &dir_b,
                 codex_dir: &empty_dir,
             },
@@ -860,7 +822,7 @@ mod tests {
         fs::write(tmp.path().join("shallow.jsonl"), "{}").unwrap();
 
         let mut files = Vec::new();
-        collect_jsonl_files(tmp.path(), &mut files, Source::Claude, false);
+        collect_jsonl_files(tmp.path(), &mut files, Source::Claude);
 
         assert_eq!(files.len(), 1);
         assert!(files[0].0.ends_with("shallow.jsonl"));
@@ -880,7 +842,7 @@ mod tests {
         symlink(&real_file, &link).unwrap();
 
         let mut files = Vec::new();
-        collect_jsonl_files(tmp.path(), &mut files, Source::Claude, false);
+        collect_jsonl_files(tmp.path(), &mut files, Source::Claude);
 
         assert_eq!(files.len(), 1);
         assert!(files[0].0.ends_with("real.jsonl"));
@@ -908,17 +870,16 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
         )
         .unwrap();
 
-        let stats1 = index_chunks(&mut conn, false).unwrap();
+        let stats1 = index_chunks(&mut conn).unwrap();
         assert_eq!(stats1.chunks_created, 1);
 
-        let stats2 = index_chunks(&mut conn, false).unwrap();
+        let stats2 = index_chunks(&mut conn).unwrap();
         assert_eq!(stats2.chunks_created, 0);
     }
 
@@ -1006,13 +967,12 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
         )
         .unwrap();
-        index_chunks(&mut conn, false).unwrap();
+        index_chunks(&mut conn).unwrap();
 
         let chunk_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))
@@ -1056,7 +1016,7 @@ mod tests {
             )
             .unwrap();
         }
-        index_chunks(&mut conn, false).unwrap();
+        index_chunks(&mut conn).unwrap();
 
         let chunk_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))
@@ -1111,13 +1071,12 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
         )
         .unwrap();
-        index_chunks(&mut conn, false).unwrap();
+        index_chunks(&mut conn).unwrap();
 
         let chunk_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -24,6 +24,14 @@ pub struct IndexStats {
     pub elapsed_secs: f64,
 }
 
+impl IndexStats {
+    pub fn parse_error_detail(&self) -> Option<String> {
+        self.first_error
+            .as_ref()
+            .map(|err| format!("Failed to parse {} files — {err}", self.parse_errors))
+    }
+}
+
 enum IndexOutcome {
     Indexed,
     Unchanged,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,9 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
 
-use amici::cli::{Spinner, done, embed_with_spinners, try_expand_shorthand};
+use amici::cli::{
+    Spinner, done, embed_with_spinners, exit_error, progress_step, try_expand_shorthand,
+};
 use amici::logging::init_subscriber;
 use amici::model::download_and_verify_model;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
@@ -172,17 +174,19 @@ fn run_index(force: bool, verbose: bool, db_path: &Option<PathBuf>) -> Result<()
 
     let sp = Spinner::new("Indexing sessions...");
     let stats = indexer::index_sessions(&mut conn, force, verbose)?;
-    if stats.indexed > 0 {
-        sp.finish(&format!(
+    let main_msg = if stats.indexed > 0 {
+        format!(
             "Indexed {} sessions in {:.1}s",
             stats.indexed, stats.elapsed_secs
-        ));
+        )
     } else {
-        sp.finish(&format!("{} sessions up to date", stats.total_sessions));
-    }
-    if let Some(ref err) = stats.first_error {
-        eprintln!("  Failed to parse {} files — {err}", stats.parse_errors);
-    }
+        format!("{} sessions up to date", stats.total_sessions)
+    };
+    let detail = stats
+        .first_error
+        .as_ref()
+        .map(|err| format!("Failed to parse {} files — {err}", stats.parse_errors));
+    sp.finish_with_detail(&main_msg, detail.as_deref());
 
     let sp = Spinner::new("Creating chunks...");
     let chunk_stats = indexer::index_chunks(&mut conn, verbose)?;
@@ -195,14 +199,12 @@ fn run_index(force: bool, verbose: bool, db_path: &Option<PathBuf>) -> Result<()
     let model_cached = cached_artifacts(ModelId::default())
         .map(|opt| opt.is_some())
         .unwrap_or(false);
-    eprintln!(
-        "  Model: {}",
-        if model_cached {
-            "ready (run `recall embed` to embed chunks)"
-        } else {
-            "not installed (run `recall model download`)"
-        }
-    );
+    let model_status = if model_cached {
+        "ready (run `recall embed` to embed chunks)"
+    } else {
+        "not installed (run `recall model download`)"
+    };
+    progress_step(&[&format!("Model: {model_status}")]);
 
     Ok(())
 }
@@ -596,7 +598,7 @@ fn main() {
 
     if let Err(e) = run() {
         let msg = format!("{e:#}");
-        eprintln!("Error: {msg}");
+        exit_error(&msg);
         let code = if USER_ERROR_MARKERS.iter().any(|m| msg.contains(m)) {
             1
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use clap::{Parser, Subcommand};
 use rurico::embed::{Embed, ModelId, cached_artifacts};
 use rurico::model_probe::handle_probe_if_needed;
 use rusqlite::Connection;
+use tracing::{info, warn};
 
 use crate::parser::Source;
 
@@ -149,8 +150,8 @@ fn resolve_db_path(db_path: &Option<PathBuf>) -> Result<PathBuf> {
 fn try_load_embedder_cached() -> Option<Arc<dyn Embed>> {
     match try_load_embedder_with(
         || cached_artifacts(ModelId::default()),
-        |e| eprintln!("Warning: failed to delete corrupt model files: {e}"),
-        |e| eprintln!("Warning: embedder probe failed: {e}"),
+        |e| warn!(error = %e, "failed to delete corrupt model files"),
+        |e| warn!(error = %e, "embedder probe failed"),
     ) {
         Ok(e) => Some(e),
         Err(DegradedReason::NotInstalled) => {
@@ -160,7 +161,7 @@ fn try_load_embedder_cached() -> Option<Arc<dyn Embed>> {
             None
         }
         Err(reason) => {
-            eprintln!("Warning: embedder unavailable ({reason}); using text search only");
+            warn!(%reason, "embedder unavailable; using text search only");
             None
         }
     }
@@ -251,8 +252,8 @@ fn run_embed(_verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
 fn load_cached_embedder() -> Result<Arc<dyn Embed>> {
     try_load_embedder_with(
         || cached_artifacts(ModelId::default()),
-        |e| eprintln!("Warning: failed to delete corrupt model files: {e}"),
-        |e| eprintln!("Warning: embedder probe failed: {e}"),
+        |e| warn!(error = %e, "failed to delete corrupt model files"),
+        |e| warn!(error = %e, "embedder probe failed"),
     )
     .map_err(|reason| {
         let hint = match reason {
@@ -271,7 +272,7 @@ fn run_model_download() -> Result<()> {
     download_and_verify_model().map_err(|e| anyhow::anyhow!("{e}"))
 }
 
-fn run_search(cmd: Command, verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_search(cmd: Command, _verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
     let Command::Search {
         query,
         project,
@@ -330,10 +331,7 @@ fn run_search(cmd: Command, verbose: bool, db_path: &Option<PathBuf>) -> Result<
                 total += r.embedded;
             }
             Err(e) => {
-                eprintln!("Warning: post-search embedding skipped: {e}");
-                if verbose {
-                    eprintln!("  {e:#}");
-                }
+                warn!(error = ?e, "post-search embedding skipped");
             }
         };
         handle(embedder::embed_near_sessions(
@@ -344,8 +342,8 @@ fn run_search(cmd: Command, verbose: bool, db_path: &Option<PathBuf>) -> Result<
             None,
         ));
         handle(embedder::embed_recent_chunks(&mut conn, emb, 10, None));
-        if total > 0 && verbose {
-            eprintln!("Embedded {total} chunks (nearby + recent)");
+        if total > 0 {
+            info!(total, "Embedded chunks (nearby + recent)");
         }
     }
 
@@ -369,7 +367,7 @@ fn show_session(
             Ok(parser::SessionData {
                 session_id: row.get(0)?,
                 source: Source::from_db(&source_str).unwrap_or_else(|| {
-                    eprintln!("Warning: unknown source '{source_str}', defaulting to claude");
+                    warn!(source = %source_str, "unknown source, defaulting to claude");
                     Source::Claude
                 }),
                 file_path: row.get(2)?,
@@ -539,7 +537,7 @@ fn print_result(i: usize, r: &search::SearchResult) {
         if e.kind() == ErrorKind::BrokenPipe {
             process::exit(0);
         }
-        eprintln!("Warning: failed to write result: {e}");
+        warn!(error = %e, "failed to write result");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,12 +168,12 @@ fn try_load_embedder_cached() -> Option<Arc<dyn Embed>> {
 
 // -- Subcommands --
 
-fn run_index(force: bool, verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_index(force: bool, _verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
     let path = resolve_db_path(db_path)?;
     let mut conn = open_or_create_db(&path)?;
 
     let sp = Spinner::new("Indexing sessions...");
-    let stats = indexer::index_sessions(&mut conn, force, verbose)?;
+    let stats = indexer::index_sessions(&mut conn, force)?;
     let main_msg = if stats.indexed > 0 {
         format!(
             "Indexed {} sessions in {:.1}s",
@@ -189,7 +189,7 @@ fn run_index(force: bool, verbose: bool, db_path: &Option<PathBuf>) -> Result<()
     sp.finish_with_detail(&main_msg, detail.as_deref());
 
     let sp = Spinner::new("Creating chunks...");
-    let chunk_stats = indexer::index_chunks(&mut conn, verbose)?;
+    let chunk_stats = indexer::index_chunks(&mut conn)?;
     if chunk_stats.chunks_created > 0 {
         sp.finish(&format!("Created {} chunks", chunk_stats.chunks_created));
     } else {
@@ -289,8 +289,8 @@ fn run_search(cmd: Command, verbose: bool, db_path: &Option<PathBuf>) -> Result<
 
     // Auto-index FTS5 + chunks (fast: skips scan if dirs unchanged)
     let sp = Spinner::new("Indexing...");
-    let stats = indexer::index_sessions(&mut conn, false, verbose)?;
-    let chunk_stats = indexer::index_chunks(&mut conn, verbose)?;
+    let stats = indexer::index_sessions(&mut conn, false)?;
+    let chunk_stats = indexer::index_chunks(&mut conn)?;
     if stats.indexed > 0 || chunk_stats.chunks_created > 0 {
         sp.finish(&format!(
             "Indexed {} sessions, {} chunks",

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ use crate::parser::Source;
 /// Keep in sync with bail! sites: `run()` and `find_candidate_sessions()`.
 const USER_ERROR_MARKERS: &[&str] = &["search query is required", "Invalid search query"];
 
+const LOG_FILTER_VERBOSE: &str = "recall=info";
+const LOG_FILTER_DEFAULT: &str = "recall=warn";
+
 #[derive(Parser)]
 #[command(name = "recall", about = "Search past Claude Code and Codex sessions")]
 struct Cli {
@@ -148,12 +151,16 @@ fn resolve_db_path(db_path: &Option<PathBuf>) -> Result<PathBuf> {
     }
 }
 
-fn try_load_embedder_cached() -> Option<Arc<dyn Embed>> {
-    match try_load_embedder_with(
+fn open_cached_embedder() -> Result<Arc<dyn Embed>, DegradedReason> {
+    try_load_embedder_with(
         || cached_artifacts(ModelId::default()),
         |e| warn!(error = %e, "failed to delete corrupt model files"),
         |e| warn!(error = %e, "embedder probe failed"),
-    ) {
+    )
+}
+
+fn try_load_embedder_cached() -> Option<Arc<dyn Embed>> {
+    match open_cached_embedder() {
         Ok(e) => Some(e),
         Err(DegradedReason::NotInstalled) => {
             cli_info(
@@ -201,12 +208,12 @@ fn run_index(force: bool, _verbose: bool, db_path: &Option<PathBuf>) -> Result<(
     let model_cached = cached_artifacts(ModelId::default())
         .map(|opt| opt.is_some())
         .unwrap_or(false);
-    let model_status = if model_cached {
-        "ready (run `recall embed` to embed chunks)"
+    let model_line = if model_cached {
+        "Model: ready (run `recall embed` to embed chunks)"
     } else {
-        "not installed (run `recall model download`)"
+        "Model: not installed (run `recall model download`)"
     };
-    progress_step(&[&format!("Model: {model_status}")]);
+    progress_step(&[model_line]);
 
     Ok(())
 }
@@ -251,12 +258,7 @@ fn run_embed(_verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
 }
 
 fn load_cached_embedder() -> Result<Arc<dyn Embed>> {
-    try_load_embedder_with(
-        || cached_artifacts(ModelId::default()),
-        |e| warn!(error = %e, "failed to delete corrupt model files"),
-        |e| warn!(error = %e, "embedder probe failed"),
-    )
-    .map_err(|reason| {
+    open_cached_embedder().map_err(|reason| {
         let hint = match reason {
             DegradedReason::NotInstalled => {
                 "embedding model not installed; run `recall model download`"
@@ -293,14 +295,19 @@ fn run_search(cmd: Command, _verbose: bool, db_path: &Option<PathBuf>) -> Result
     let sp = Spinner::new("Indexing...");
     let stats = indexer::index_sessions(&mut conn, false)?;
     let chunk_stats = indexer::index_chunks(&mut conn)?;
-    if stats.indexed > 0 || chunk_stats.chunks_created > 0 {
-        sp.finish(&format!(
+    let main_msg = if stats.indexed > 0 || chunk_stats.chunks_created > 0 {
+        format!(
             "Indexed {} sessions, {} chunks",
             stats.indexed, chunk_stats.chunks_created
-        ));
+        )
     } else {
-        sp.finish(&format!("{} sessions", stats.total_sessions));
-    }
+        format!("{} sessions", stats.total_sessions)
+    };
+    let detail = stats
+        .first_error
+        .as_ref()
+        .map(|err| format!("Failed to parse {} files — {err}", stats.parse_errors));
+    sp.finish_with_detail(&main_msg, detail.as_deref());
 
     let embedder = try_load_embedder_cached();
 
@@ -570,9 +577,9 @@ fn run() -> Result<()> {
     };
 
     let default_filter = if cli.verbose {
-        "recall=info"
+        LOG_FILTER_VERBOSE
     } else {
-        "recall=warn"
+        LOG_FILTER_DEFAULT
     };
     init_subscriber(default_filter);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,11 +191,7 @@ fn run_index(force: bool, db_path: &Option<PathBuf>) -> Result<()> {
     } else {
         format!("{} sessions up to date", stats.total_sessions)
     };
-    let detail = stats
-        .first_error
-        .as_ref()
-        .map(|err| format!("Failed to parse {} files — {err}", stats.parse_errors));
-    sp.finish_with_detail(&main_msg, detail.as_deref());
+    sp.finish_with_detail(&main_msg, stats.parse_error_detail().as_deref());
 
     let sp = Spinner::new("Creating chunks...");
     let chunk_stats = indexer::index_chunks(&mut conn)?;
@@ -303,11 +299,7 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<()> {
     } else {
         format!("{} sessions", stats.total_sessions)
     };
-    let detail = stats
-        .first_error
-        .as_ref()
-        .map(|err| format!("Failed to parse {} files — {err}", stats.parse_errors));
-    sp.finish_with_detail(&main_msg, detail.as_deref());
+    sp.finish_with_detail(&main_msg, stats.parse_error_detail().as_deref());
 
     let embedder = try_load_embedder_cached();
 
@@ -339,7 +331,7 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<()> {
                 total += r.embedded;
             }
             Err(e) => {
-                warn!(error = ?e, "post-search embedding skipped");
+                warn!(error = %e, "post-search embedding skipped");
             }
         };
         handle(embedder::embed_near_sessions(

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use std::process;
 use std::sync::Arc;
 
 use amici::cli::{Spinner, done, embed_with_spinners, try_expand_shorthand};
+use amici::logging::init_subscriber;
 use amici::model::download_and_verify_model;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
 use anyhow::{Context, Result};
@@ -566,6 +567,13 @@ fn run() -> Result<()> {
         Some(expanded) => Cli::parse_from(expanded),
         None => Cli::parse_from(args),
     };
+
+    let default_filter = if cli.verbose {
+        "recall=info"
+    } else {
+        "recall=warn"
+    };
+    init_subscriber(default_filter);
 
     match cli.command {
         Some(Command::Index { force }) => run_index(force, cli.verbose, &cli.db_path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,8 @@ use std::process;
 use std::sync::Arc;
 
 use amici::cli::{
-    Spinner, done, embed_with_spinners, exit_error, progress_step, try_expand_shorthand,
+    Spinner, done, embed_with_spinners, exit_error, info as cli_info, progress_step,
+    try_expand_shorthand,
 };
 use amici::logging::init_subscriber;
 use amici::model::download_and_verify_model;
@@ -155,8 +156,8 @@ fn try_load_embedder_cached() -> Option<Arc<dyn Embed>> {
     ) {
         Ok(e) => Some(e),
         Err(DegradedReason::NotInstalled) => {
-            eprintln!(
-                "Note: embedding model not installed; using text search only. Run `recall model download` to enable semantic search."
+            cli_info(
+                "note: embedding model not installed; using text search only. Run `recall model download` to enable semantic search.",
             );
             None
         }
@@ -439,8 +440,8 @@ fn run_show(session_id: &str, verbose: bool, db_path: &Option<PathBuf>) -> Resul
 fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
     let path = resolve_db_path(db_path)?;
     if !path.exists() {
-        println!("Database not found at {}", path.display());
-        println!("Run `recall index` to create the index.");
+        cli_info(&format!("database not found at {}", path.display()));
+        cli_info("run `recall index` to create the index.");
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ fn try_load_embedder_cached() -> Option<Arc<dyn Embed>> {
 
 // -- Subcommands --
 
-fn run_index(force: bool, _verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_index(force: bool, db_path: &Option<PathBuf>) -> Result<()> {
     let path = resolve_db_path(db_path)?;
     let mut conn = open_or_create_db(&path)?;
 
@@ -218,7 +218,7 @@ fn run_index(force: bool, _verbose: bool, db_path: &Option<PathBuf>) -> Result<(
     Ok(())
 }
 
-fn run_embed(_verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_embed(db_path: &Option<PathBuf>) -> Result<()> {
     let path = resolve_db_path(db_path)?;
     let mut conn = open_or_create_db(&path)?;
 
@@ -275,7 +275,7 @@ fn run_model_download() -> Result<()> {
     download_and_verify_model().map_err(|e| anyhow::anyhow!("{e}"))
 }
 
-fn run_search(cmd: Command, _verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<()> {
     let Command::Search {
         query,
         project,
@@ -584,10 +584,10 @@ fn run() -> Result<()> {
     init_subscriber(default_filter);
 
     match cli.command {
-        Some(Command::Index { force }) => run_index(force, cli.verbose, &cli.db_path),
-        Some(Command::Embed) => run_embed(cli.verbose, &cli.db_path),
+        Some(Command::Index { force }) => run_index(force, &cli.db_path),
+        Some(Command::Embed) => run_embed(&cli.db_path),
         Some(Command::Model(ModelCommand::Download)) => run_model_download(),
-        Some(cmd @ Command::Search { .. }) => run_search(cmd, cli.verbose, &cli.db_path),
+        Some(cmd @ Command::Search { .. }) => run_search(cmd, &cli.db_path),
         Some(Command::Show { session_id }) => run_show(&session_id, cli.verbose, &cli.db_path),
         Some(Command::Status) => run_status(cli.verbose, &cli.db_path),
         None => {

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,6 +7,7 @@ use rurico::embed::Embed;
 use rurico::storage::{f32_as_bytes, rrf_merge};
 use rusqlite::Connection;
 use rusqlite::types::{ToSql, ToSqlOutput};
+use tracing::warn;
 
 use crate::date::MS_PER_DAY;
 use crate::hybrid;
@@ -156,11 +157,11 @@ fn expand_short_terms(conn: &Connection, sanitized_query: &str) -> String {
                 .query_map([&pattern], |row| row.get::<_, String>(0))
                 .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())
                 .unwrap_or_else(|e| {
-                    eprintln!("Warning: term expansion failed for '{unquoted}': {e}");
+                    warn!(error = %e, unquoted, "term expansion failed");
                     Vec::new()
                 }),
             Err(e) => {
-                eprintln!("Warning: term expansion failed for '{unquoted}': {e}");
+                warn!(error = %e, unquoted, "term expansion failed");
                 Vec::new()
             }
         }
@@ -264,7 +265,7 @@ fn find_candidate_sessions(conn: &Connection, sq: &SearchQuery) -> Result<Vec<(S
                 "Invalid search query: {err_msg}. Use words, \"quoted phrases\", or AND/OR/NOT operators."
             );
         }
-        eprintln!("Warning: {skipped} row(s) skipped during search: {err_msg}");
+        warn!(skipped, %err_msg, "rows skipped during search");
     }
     Ok(ranked)
 }
@@ -300,9 +301,7 @@ fn fetch_session_metadata(
                 let source = match Source::from_db(&source_str) {
                     Some(s) => s,
                     None => {
-                        eprintln!(
-                            "Warning: unknown source {source_str:?} for session {session_id}"
-                        );
+                        warn!(source = %source_str, session_id, "unknown source");
                         continue;
                     }
                 };
@@ -320,14 +319,14 @@ fn fetch_session_metadata(
             }
             Err(e) => {
                 if db_errors == 0 {
-                    eprintln!("Warning: metadata query error: {e}");
+                    warn!(error = %e, "metadata query error");
                 }
                 db_errors += 1;
             }
         }
     }
     if db_errors > 1 {
-        eprintln!("Warning: {db_errors} metadata row(s) failed");
+        warn!(db_errors, "metadata rows failed");
     }
     Ok(map)
 }
@@ -380,7 +379,7 @@ fn snippet_or_default(result: rusqlite::Result<String>, sid: &str) -> Option<Str
         Ok(s) => Some(s),
         Err(rusqlite::Error::QueryReturnedNoRows) => None,
         Err(e) => {
-            eprintln!("Warning: snippet extraction failed for session {sid}: {e}");
+            warn!(error = %e, session_id = sid, "snippet extraction failed");
             None
         }
     }
@@ -491,7 +490,7 @@ pub fn search_with_embedder(
         let vec_hits = match vec_search(conn, embedder, query, candidate_limit) {
             Ok(hits) => hits,
             Err(e) => {
-                eprintln!("Warning: vector search failed, using text search only: {e}");
+                warn!(error = %e, "vector search failed, using text search only");
                 Vec::new()
             }
         };
@@ -956,7 +955,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },
@@ -992,7 +990,6 @@ mod tests {
             &mut conn,
             &IndexOptions {
                 force: false,
-                verbose: false,
                 claude_dir: &claude_dir,
                 codex_dir: &codex_dir,
             },

--- a/src/search.rs
+++ b/src/search.rs
@@ -374,12 +374,12 @@ fn score_and_sort(
     results.into_iter().map(|(r, _)| r).collect()
 }
 
-fn snippet_or_default(result: rusqlite::Result<String>, sid: &str) -> Option<String> {
+fn snippet_or_default(result: rusqlite::Result<String>, session_id: &str) -> Option<String> {
     match result {
         Ok(s) => Some(s),
         Err(rusqlite::Error::QueryReturnedNoRows) => None,
         Err(e) => {
-            warn!(error = %e, session_id = sid, "snippet extraction failed");
+            warn!(error = %e, session_id, "snippet extraction failed");
             None
         }
     }


### PR DESCRIPTION
## 概要

recall に `tracing` を導入し、散在していた 39 箇所の `eprintln!` を `tracing::{warn,info,debug}` / `amici::cli::*` / `Spinner::finish_with_detail` へ移行した。sae #66・yomu #100 と同種の整理を recall 側に適用することで、3 ツール間の CLI UI とログ出力の方式を統一する（amici #9 が提供するヘルパーを全面採用）。

## 変更点

- `Cargo.toml`: `tracing` + `tracing-subscriber` を追加、amici rev を `ae6ed39` に更新
- `main.rs`: `amici::logging::init_subscriber` を呼び出し。`--verbose` フラグが `recall=info`（verbose 時）/ `recall=warn`（デフォルト）を切り替える。`run_index` / `run_embed` / `run_search` から不要になった `_verbose` 引数を削除
- `run_show` / `run_status` の `verbose` 引数は保持（標準出力のゲート用途で tracing 対象外）
- ファイル単位の診断イベント（mtime・symlink・非 UTF-8 パス・unknown role）を `debug!` に降格し、デフォルト出力を無音化。`parse failed` は `info!` を維持し、`--verbose` で取りこぼしセッションを確認できるようにした
- `migrate_fts_if_needed` / `migrate_vec_chunks_if_needed` を `amici::migration::notify_schema_change` 経由に変更
- プレフィックス統一: `Error:` → `error:`、`Warning:` → `warning:`、`Note:` → `note:`（sae・yomu に合わせる）
- `IndexStats::parse_error_detail()` メソッドを追加し、失敗サマリー行の生成ロジックを集約
- `println!` は実データ（`recall status` カウンタ / `recall search` 結果ヘッダ / `recall show` markdown）のみ保持

## 設計判断

- `--verbose` は `init_subscriber` のフィルタ文字列を切り替えるだけに限定し、呼び出し先への引数伝播をなくした。関心の分離が明確になり、将来のフィルタ調整も一箇所で済む
- `run_show` / `run_status` の `verbose` 引数は削除しなかった。これらはログレベルではなく stdout への追加出力（ファイルパス / DB パス表示）を制御しており、tracing で代替できない

## テスト計画

- [x] `cargo test` — 109 passed
- [x] `cargo clippy --all-targets -- -D warnings` — warnings なし
- [x] `cargo fmt --check` — 差分なし
- [ ] `recall search <query>` でデフォルト動作が無音であることを確認
- [ ] `recall --verbose search <query>` で `parse failed` ログが stderr に出ることを確認

## 関連

- Closes #33
- thkt/amici#9（ヘルパー提供元、マージ済）
- thkt/sae#66（同種リファクタ、マージ済）
- thkt/yomu#100（同種リファクタ、マージ済）
