### PR TITLE
スラッシュを含む検索クエリで FTS5 構文エラーが発生する不具合を修正

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -64,7 +64,8 @@ struct SearchQuery {
 
 /// Neutralize FTS5 special syntax in user queries: column-filters (`role:admin`),
 /// start-of-column (`^term`), `NEAR()` grouping, `+` required-match prefix,
-/// and unbalanced quotes (auto-balanced to prevent syntax errors).
+/// slash-prefixed tokens (`/challenge`), and unbalanced quotes (auto-balanced
+/// to prevent syntax errors).
 fn sanitize_fts_query(query: &str) -> String {
     let result = query
         .split_whitespace()
@@ -75,9 +76,13 @@ fn sanitize_fts_query(query: &str) -> String {
         .map(|w| {
             let w = w.trim_start_matches(['^', '+', '-']);
             let w = w.trim_matches(['(', ')']);
-            if (w.contains(':') || w.contains('-')) && !w.starts_with('"') {
+            if (w.contains(':') || w.contains('-') || w.contains('/')) && !w.starts_with('"') {
                 let clean = w.replace('"', "");
-                format!("\"{clean}\"")
+                if clean.chars().any(char::is_alphanumeric) {
+                    format!("\"{clean}\"")
+                } else {
+                    String::new()
+                }
             } else {
                 w.to_owned()
             }
@@ -864,6 +869,21 @@ mod tests {
     }
 
     #[test]
+    fn test_slash_command_query_matches_body() {
+        let (_dir, conn) = setup_test_db();
+        insert_session(&conn, "s1", "claude", "/proj", 1709251200000);
+        insert_message(&conn, "s1", "user", "used /challenge to review the plan");
+
+        let results = search(&conn, "/challenge", &SearchOptions::default()).unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "quoted slash token should match body text"
+        );
+        assert_eq!(results[0].session.session_id, "s1");
+    }
+
+    #[test]
     fn test_score_and_sort_respects_limit() {
         let now_ms = 1_750_000_000_000_i64;
         let candidates: Vec<_> = (0..5)
@@ -919,6 +939,13 @@ mod tests {
             ("mlx-rs embedding", "\"mlx-rs\" embedding"),
             ("state-of-the-art", "\"state-of-the-art\""),
             ("\"mlx-rs\"", "\"mlx-rs\""),
+            // Slash-containing tokens → quoted (prevents FTS5 syntax error)
+            ("/challenge", "\"/challenge\""),
+            ("use /foo today", "use \"/foo\" today"),
+            ("path/to/file", "\"path/to/file\""),
+            // Bare slashes have no alphanumerics → dropped
+            ("/", ""),
+            ("//", ""),
             // Quote balancing
             ("\"unbalanced", "\"unbalanced\""),
             ("\"balanced\"", "\"balanced\""),


### PR DESCRIPTION
## 概要

- `sanitize_fts_query` が `/` をエスケープ対象に含めていなかったため、`/challenge`・`/polish`・`/fix` 等の Claude Code スラッシュコマンド文字列を検索すると `fts5: syntax error near "/"` が発生していた
- `/` を FTS5 フレーズリテラルのクォート対象に追加し、`/challenge` → `"/challenge"` に変換するよう修正
- 英数字を含まないトークン（`/`・`//` 単体）は空文字列になるため、既存の `filter(!is_empty)` で除去し、`syntax error near ""` も回避

## 検証

- 実 DB で `recall search "/challenge" --limit 3` を実行し、`/challenge` を含むセッション 3 件が返ることを確認
- ユニットテスト 110 件パス、`clippy` クリーン
- 追加テスト: `test_slash_command_query_matches_body`（session id 一致のアサーション）+ サニタイズテーブルケース 5 件（`/challenge`・`use /foo today`・`path/to/file`・`/`・`//`）

## スコープ外

- `/`・`//`・`^`・`+` を単独で入力した場合は引き続き `syntax error near ""` が発生する。これは `^` 単体で同様の挙動が既にあった既存の制限であり、本 PR で導入したものではない
- `/a`・`a/` のような 1〜2 文字のスラッシュトークンはクォートされるが、trigram トークナイザーが 3 文字以上を要求するためマッチしない。Claude Code のスラッシュコマンドはすべて 3 文字以上なので、実ユーザーのワークフローには影響なし（Codex レビューで敵対的入力のみに該当すると確認済み）

## 関連

- #13 (`rurico` の `SanitizedFtsQuery` API へのリファクタ): #13 がマージされたらスラッシュ処理を `rurico` 側にも同期する
