### PR TITLE
search パスで embedder 不変条件を if let Some で型レベル保証

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -481,10 +481,9 @@ pub fn search_with_embedder(
     let sq = build_search_query(conn, query, opts, now_ms);
     let fts_ranked = find_candidate_sessions(conn, &sq)?;
 
-    let use_hybrid = embedder.is_some() && has_vec_data(conn);
-
-    if use_hybrid {
-        let embedder = embedder.unwrap();
+    if let Some(embedder) = embedder
+        && has_vec_data(conn)
+    {
         let candidate_limit = opts.limit * 3;
 
         let fts_hits: Vec<(String, f64)> = fts_ranked


### PR DESCRIPTION
## 背景と目的

`bool` フラグで `Option` の状態を追跡し `unwrap()` を呼ぶパターンは、コンパイラが検証できない暗黙の不変条件に依存していた。将来のリファクタリングでこの同期が崩れた場合、メッセージなしの panic が発生し診断が困難になる。`if let Some(embedder) = embedder && has_vec_data(conn)` に変換することで、値のバインドと条件チェックを1つのブランチに統合し、潜在的な panic パスを型システムで排除する。

## 変更内容

- `use_hybrid` bool と `embedder.unwrap()` の2段構えを `if let Some(embedder) = embedder && has_vec_data(conn)` の let chain に置き換え — コンパイラが `Some` であることを保証する範囲でのみ値を使用できるよう強制する

## 設計判断

- ヘルパー関数への抽出は採用しなかった。行数・間接参照ともに増加するのに対し、`if let` + `&&`（let chains、Rust 1.88 で安定化）は同等の表現力を1段のインデントで実現し、不変条件をコンパイラに直接委譲できる

## テスト方法

1. `cargo check` — コンパイル成功を確認
2. `cargo clippy --all-targets --all-features -- -D warnings` — 警告ゼロを確認
3. `cargo test` — 110テスト全通過を確認（hybrid パス: `test_hybrid_search_merges_fts_and_vector`、`test_hybrid_search_falls_back_on_vector_error`）
4. 挙動変化なし — リファクタリングのみ

## 関連

- Closes #17
