### PR TITLE
FTSとハイブリッド検索パスの新しさ重みを統一

### DIFF
--- a/src/hybrid.rs
+++ b/src/hybrid.rs
@@ -3,6 +3,7 @@ use std::f64::consts::LN_2;
 use crate::date::MS_PER_DAY;
 
 pub(crate) const RECENCY_HALF_LIFE_DAYS: f64 = 30.0;
+pub(crate) const RECENCY_BOOST_WEIGHT: f64 = 0.2;
 
 /// Exponential recency decay: 1.0 for now, 0.5 at half-life, approaching 0.0.
 pub(crate) fn recency_decay(now_ms: i64, ts: Option<i64>) -> f64 {
@@ -18,14 +19,16 @@ pub(crate) fn recency_decay(now_ms: i64, ts: Option<i64>) -> f64 {
 /// Apply exponential recency boost to RRF scores.
 ///
 /// `get_timestamp` resolves a session_id to its epoch-ms timestamp.
+/// `weight` scales the boost's influence on the final score.
 pub(crate) fn apply_recency_boost(
     results: &mut [(String, f64)],
     get_timestamp: impl Fn(&str) -> Option<i64>,
     now_ms: i64,
+    weight: f64,
 ) {
     for (session_id, score) in results.iter_mut() {
         let boost = recency_decay(now_ms, get_timestamp(session_id));
-        *score *= 1.0 + boost;
+        *score *= 1.0 + weight * boost;
     }
     results.sort_by(|a, b| b.1.total_cmp(&a.1));
 }
@@ -92,6 +95,7 @@ mod tests {
             &mut results,
             |sid| timestamps.get(sid).copied().flatten(),
             now_ms,
+            0.2,
         );
 
         assert_eq!(results[0].0, "new");
@@ -106,9 +110,26 @@ mod tests {
     #[test]
     fn test_recency_boost_no_timestamp() {
         let mut results = vec![("no-ts".to_owned(), 0.5)];
-        apply_recency_boost(&mut results, |_| None, 1_000_000);
+        apply_recency_boost(&mut results, |_| None, 1_000_000, 0.2);
 
         assert!((results[0].1 - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_apply_recency_boost_scales_with_weight() {
+        // At now (age=0), recency_decay returns 1.0, so final score = base * (1.0 + weight).
+        let now_ms = 1_000_000;
+        let base = 1.0;
+
+        for (weight, expected) in [(0.0, 1.0), (0.2, 1.2), (1.0, 2.0)] {
+            let mut results = vec![("s1".to_owned(), base)];
+            apply_recency_boost(&mut results, |_| Some(now_ms), now_ms, weight);
+            assert!(
+                (results[0].1 - expected).abs() < 1e-10,
+                "weight={weight} → expected {expected}, got {}",
+                results[0].1
+            );
+        }
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -10,10 +10,8 @@ use rusqlite::types::{ToSql, ToSqlOutput};
 use tracing::warn;
 
 use crate::date::MS_PER_DAY;
-use crate::hybrid;
+use crate::hybrid::{self, RECENCY_BOOST_WEIGHT};
 use crate::parser::{SessionData, Source};
-
-const RECENCY_BOOST_WEIGHT: f64 = 0.2;
 
 pub struct SearchResult {
     pub session: SessionData,
@@ -507,6 +505,7 @@ pub fn search_with_embedder(
             &mut merged,
             |sid| meta_map.get(sid).and_then(|sd| sd.timestamp),
             now_ms,
+            RECENCY_BOOST_WEIGHT,
         );
         merged.truncate(opts.limit);
 
@@ -559,6 +558,28 @@ mod tests {
         conn.execute(
             "INSERT INTO messages (session_id, role, text) VALUES (?1, ?2, ?3)",
             rusqlite::params![sid, role, text],
+        )
+        .unwrap();
+    }
+
+    fn insert_chunk_with_embedding(
+        conn: &Connection,
+        chunk_id: i64,
+        sid: &str,
+        text: &str,
+        ts: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO qa_chunks (id, session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
+             VALUES (?1, ?2, 'q', 'a', ?3, ?4, ?5)",
+            rusqlite::params![chunk_id, sid, text, ts, format!("hash{chunk_id}")],
+        )
+        .unwrap();
+        let embedding = MockEmbedder::deterministic_vector(text);
+        let embedding_bytes: &[u8] = f32_as_bytes(&embedding);
+        conn.execute(
+            "INSERT INTO vec_chunks (chunk_id, embedding) VALUES (?1, ?2)",
+            rusqlite::params![chunk_id, embedding_bytes],
         )
         .unwrap();
     }
@@ -1067,19 +1088,7 @@ mod tests {
         insert_session(&conn, "s2", "claude", "/proj", now_ms);
         insert_message(&conn, "s2", "user", "unrelated topic about weather");
 
-        conn.execute(
-            "INSERT INTO qa_chunks (id, session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
-             VALUES (1, 's2', 'q', 'a', 'authentication implementation details', ?1, 'hash1')",
-            [now_ms],
-        )
-        .unwrap();
-        let embedding = MockEmbedder::deterministic_vector("authentication");
-        let embedding_bytes: &[u8] = f32_as_bytes(&embedding);
-        conn.execute(
-            "INSERT INTO vec_chunks (chunk_id, embedding) VALUES (1, ?1)",
-            [embedding_bytes],
-        )
-        .unwrap();
+        insert_chunk_with_embedding(&conn, 1, "s2", "authentication", now_ms);
 
         assert!(has_vec_data(&conn));
 
@@ -1110,6 +1119,47 @@ mod tests {
     }
 
     #[test]
+    fn test_hybrid_recency_boost_favors_newer() {
+        let (_dir, conn) = setup_test_db();
+        let now_ms = 1_750_000_000_000_i64;
+
+        // Two sessions with identical FTS-matching text and identical embedding content.
+        // Only the timestamp differs; hybrid path must rank the newer one first.
+        for (sid, ts) in [("old", now_ms - 365 * MS_PER_DAY), ("new", now_ms)] {
+            insert_session(&conn, sid, "claude", "/proj", ts);
+            insert_message(&conn, sid, "user", "authentication flow discussion");
+        }
+
+        for (chunk_id, sid) in [(1_i64, "old"), (2, "new")] {
+            insert_chunk_with_embedding(
+                &conn,
+                chunk_id,
+                sid,
+                "authentication flow discussion",
+                now_ms,
+            );
+        }
+
+        let embedder = MockEmbedder::new();
+        let results = search_with_embedder(
+            &conn,
+            "authentication",
+            &SearchOptions {
+                now_ms: Some(now_ms),
+                ..Default::default()
+            },
+            Some(&embedder),
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].session.session_id, "new",
+            "hybrid path must apply recency boost so newer session ranks first"
+        );
+    }
+
+    #[test]
     fn test_hybrid_search_falls_back_on_vector_error() {
         let (_dir, conn) = setup_test_db();
         let now_ms = 1_750_000_000_000_i64;
@@ -1118,19 +1168,7 @@ mod tests {
         insert_message(&conn, "s1", "user", "authentication flow discussion");
 
         // Need vec_chunks to trigger hybrid path
-        conn.execute(
-            "INSERT INTO qa_chunks (id, session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
-             VALUES (1, 's1', 'q', 'a', 'content', ?1, 'hash1')",
-            [now_ms],
-        )
-        .unwrap();
-        let embedding = MockEmbedder::deterministic_vector("content");
-        let embedding_bytes: &[u8] = f32_as_bytes(&embedding);
-        conn.execute(
-            "INSERT INTO vec_chunks (chunk_id, embedding) VALUES (1, ?1)",
-            [embedding_bytes],
-        )
-        .unwrap();
+        insert_chunk_with_embedding(&conn, 1, "s1", "content", now_ms);
 
         let embedder = MockEmbedder::failing_after(0);
         let results = search_with_embedder(


### PR DESCRIPTION
## 概要

`RECENCY_BOOST_WEIGHT`（0.2）がFTS専用パスにしか適用されておらず、ハイブリッド（FTS + ベクター）パスでは暗黙的に ×1.0（実質 ×2.0）が使われていた非対称な状態を修正した。

`apply_recency_boost` に `weight: f64` パラメータを追加し、定数を `hybrid.rs` に移動して両パスから参照する形に統一した。

Closes #27

## 動作変更

| パス | 変更前 | 変更後 |
|------|--------|-------|
| FTS-only | ×1.2（weight 0.2） | ×1.2（変更なし） |
| hybrid（embedderキャッシュ時のデフォルト） | ×2.0（暗黙 weight 1.0） | ×1.2（weight 0.2） |

ハイブリッドパスの目的は古いセッションも意味的に引き当てることにある。×2.0 の新しさ乗数は、ベクター検索の価値をrecency偏重で損なうため、FTSパスと揃えることでPURPOSE.md の優先度#1（精度 > 機能豊富さ）に沿う形にした。

## テスト計画

- [ ] `cargo test` — 112テスト全通過（+2新規: `test_apply_recency_boost_scales_with_weight`, `test_hybrid_recency_boost_favors_newer`）
- [ ] `cargo clippy -- -D warnings` — 警告なし
- [ ] `cargo fmt --check` — フォーマット差分なし
- [ ] hybridパスで新しいチャンクが古いチャンクより上位にランクされることを手動確認
