### PR TITLE
クエリのサニタイズとvocab展開をruricoへ委譲する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=ae6ed39#ae6ed39f7a845ebd1aef40e9f126cc2c5dc5e308"
+source = "git+https://github.com/thkt/amici?rev=2a8c734#2a8c734f011d02987de98a1f290f44114e6a413d"
 dependencies = [
  "rurico",
  "rusqlite",
@@ -1661,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1693,9 +1693,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
+source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
+source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2376,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -2802,9 +2802,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -2958,11 +2958,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2971,7 +2971,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3270,6 +3270,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/thkt/recall"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "ae6ed39" }
+amici = { git = "https://github.com/thkt/amici", rev = "2a8c734" }
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 dirs = "6.0.0"
 hex = "0.4.3"
-rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c" }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
@@ -25,7 +25,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c", features = ["test-support"] }
 serial_test = "3"
 tempfile = "3"
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,10 +4,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use amici::storage::anon_placeholders;
 use anyhow::{Context, Result};
 use rurico::embed::Embed;
-use rurico::storage::{f32_as_bytes, rrf_merge};
+use rurico::storage::{SanitizeError, f32_as_bytes, prepare_match_query, rrf_merge};
 use rusqlite::Connection;
 use rusqlite::types::{ToSql, ToSqlOutput};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::date::MS_PER_DAY;
 use crate::hybrid::{self, RECENCY_BOOST_WEIGHT};
@@ -60,42 +60,6 @@ struct SearchQuery {
     params: Vec<Param>,
 }
 
-/// Neutralize FTS5 special syntax in user queries: column-filters (`role:admin`),
-/// start-of-column (`^term`), `NEAR()` grouping, `+` required-match prefix,
-/// slash-prefixed tokens (`/challenge`), and unbalanced quotes (auto-balanced
-/// to prevent syntax errors).
-fn sanitize_fts_query(query: &str) -> String {
-    let result = query
-        .split_whitespace()
-        .filter(|w| {
-            let upper = w.to_ascii_uppercase();
-            !upper.starts_with("NEAR(") && !upper.starts_with("NEAR/")
-        })
-        .map(|w| {
-            let w = w.trim_start_matches(['^', '+', '-']);
-            let w = w.trim_matches(['(', ')']);
-            if (w.contains(':') || w.contains('-') || w.contains('/')) && !w.starts_with('"') {
-                let clean = w.replace('"', "");
-                if clean.chars().any(char::is_alphanumeric) {
-                    format!("\"{clean}\"")
-                } else {
-                    String::new()
-                }
-            } else {
-                w.to_owned()
-            }
-        })
-        .filter(|w| !w.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let quote_count = result.chars().filter(|&c| c == '"').count();
-    if quote_count % 2 != 0 {
-        format!("{result}\"")
-    } else {
-        result
-    }
-}
-
 /// Escape LIKE metacharacters (`%`, `_`, `\`) for use with `ESCAPE '\'`.
 pub(crate) fn escape_like(s: &str) -> String {
     s.replace('\\', "\\\\")
@@ -129,86 +93,9 @@ fn build_session_filter(opts: &SearchOptions, now_ms: i64, params: &mut Vec<Para
     }
 }
 
-/// Trigram tokenizer requires 3+ chars; short terms are expanded to matching trigrams
-/// joined with OR so FTS5 MATCH can find them.
-fn expand_short_terms(conn: &Connection, sanitized_query: &str) -> String {
-    let mut vocab_stmt = conn.prepare(
-        "SELECT term FROM messages_vocab \
-         WHERE term LIKE ?1 ESCAPE '\\' \
-         ORDER BY cnt DESC LIMIT 25",
-    );
-    let mut parts = Vec::new();
-    for token in sanitized_query.split_whitespace() {
-        let upper = token.to_ascii_uppercase();
-        if matches!(upper.as_str(), "AND" | "OR" | "NOT") {
-            parts.push(token.to_owned());
-            continue;
-        }
-        let unquoted = token.trim_matches('"');
-        if unquoted.is_empty() {
-            continue;
-        }
-        if unquoted.chars().count() >= 3 {
-            parts.push(token.to_owned());
-            continue;
-        }
-        // Expand <3-char term via fts5vocab prefix match (e.g. "go" → "go" OR "golang" OR ...).
-        let escaped = escape_like(unquoted);
-        let pattern = format!("{escaped}%");
-        let terms: Vec<String> = match vocab_stmt.as_mut() {
-            Ok(stmt) => stmt
-                .query_map([&pattern], |row| row.get::<_, String>(0))
-                .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())
-                .unwrap_or_else(|e| {
-                    warn!(error = %e, unquoted, "term expansion failed");
-                    Vec::new()
-                }),
-            Err(e) => {
-                warn!(error = %e, unquoted, "term expansion failed");
-                Vec::new()
-            }
-        }
-        .into_iter()
-        // Trigrams like "go:" or "方針*" break FTS5 MATCH syntax; keep alphanumeric only.
-        .filter(|t| t.chars().all(char::is_alphanumeric))
-        .map(|t| format!("\"{t}\""))
-        .collect();
-        if terms.is_empty() {
-            parts.push(token.to_owned());
-        } else {
-            parts.push(format!("({})", terms.join(" OR ")));
-        }
-    }
-    // FTS5 trigram quirk: `term1 (a OR b)` is a syntax error because implicit
-    // AND (space-separated) cannot precede an OR-group. Insert explicit AND.
-    let mut result = String::new();
-    for (i, part) in parts.iter().enumerate() {
-        if i > 0 {
-            let prev = parts[i - 1].to_ascii_uppercase();
-            let curr = part.to_ascii_uppercase();
-            let is_op = |s: &str| matches!(s, "AND" | "OR" | "NOT");
-            let has_or = |s: &str| s.contains(" OR ");
-            if !is_op(&prev) && !is_op(&curr) && (has_or(part) || has_or(&parts[i - 1])) {
-                result.push_str(" AND ");
-            } else {
-                result.push(' ');
-            }
-        }
-        result.push_str(part);
-    }
-    result
-}
-
-fn build_search_query(
-    conn: &Connection,
-    query: &str,
-    opts: &SearchOptions,
-    now_ms: i64,
-) -> SearchQuery {
+fn build_search_query(fts_query: &str, opts: &SearchOptions, now_ms: i64) -> SearchQuery {
     let mut params = Vec::new();
-    let sanitized = sanitize_fts_query(query);
-    let expanded = expand_short_terms(conn, &sanitized);
-    params.push(Param::Str(expanded.clone()));
+    params.push(Param::Str(fts_query.to_owned()));
 
     let session_filter = build_session_filter(opts, now_ms, &mut params);
 
@@ -216,10 +103,95 @@ fn build_search_query(
     params.push(Param::Int(candidate_limit as i64));
 
     SearchQuery {
-        fts_query: expanded,
+        fts_query: fts_query.to_owned(),
         session_filter,
         params,
     }
+}
+
+// Trigram FTS5 quirk: `("a" OR "b") "c"` is a syntax error because implicit AND
+// cannot precede an OR-group. Distribute OR-groups into flat alternatives:
+// `(A OR B) C` → `A C OR B C`. Also strips control chars and drops sub-trigram
+// (<3 chars) expansions that trigram tokenizer cannot index.
+//
+// Mirrors sae's equivalent. Candidate for promotion to rurico once a shared
+// shape settles.
+fn clean_for_trigram(query: &str) -> String {
+    let cleaned: String = query.chars().filter(|c| !c.is_control()).collect();
+    let (fixed, or_groups) = parse_fts_segments(&cleaned);
+
+    if or_groups.is_empty() {
+        return fixed.join(" ");
+    }
+
+    let combos = cross_product(&or_groups);
+    let alternatives: Vec<String> = combos
+        .iter()
+        .map(|combo| {
+            let mut parts = combo.clone();
+            parts.extend(fixed.iter().cloned());
+            parts.join(" ")
+        })
+        .collect();
+    alternatives.join(" OR ")
+}
+
+// Split a `MatchFtsQuery` string into fixed quoted terms and OR-groups.
+// Expects fully-quoted input from `prepare_match_query`; bare tokens outside
+// `(...)` or `"..."` are silently dropped. Sub-trigram (<3 chars) entries
+// inside OR-groups are filtered out because the trigram tokenizer cannot
+// index them.
+fn parse_fts_segments(cleaned: &str) -> (Vec<String>, Vec<Vec<String>>) {
+    let mut fixed: Vec<String> = Vec::new();
+    let mut or_groups: Vec<Vec<String>> = Vec::new();
+    let mut chars = cleaned.chars();
+
+    while let Some(c) = chars.next() {
+        if c == '(' {
+            let mut group = String::new();
+            for gc in chars.by_ref() {
+                if gc == ')' {
+                    break;
+                }
+                group.push(gc);
+            }
+            let terms: Vec<String> = group
+                .split(" OR ")
+                .filter(|t| t.trim().trim_matches('"').chars().count() >= 3)
+                .map(|t| t.trim().to_owned())
+                .collect();
+            if !terms.is_empty() {
+                or_groups.push(terms);
+            }
+        } else if c == '"' {
+            let mut term = String::from('"');
+            for tc in chars.by_ref() {
+                term.push(tc);
+                if tc == '"' {
+                    break;
+                }
+            }
+            fixed.push(term);
+        }
+    }
+
+    (fixed, or_groups)
+}
+
+fn cross_product(groups: &[Vec<String>]) -> Vec<Vec<String>> {
+    if groups.is_empty() {
+        return vec![vec![]];
+    }
+    let rest = cross_product(&groups[1..]);
+    let mut result = Vec::new();
+    for term in &groups[0] {
+        for combo in &rest {
+            let mut v = vec![term.clone()];
+            v.extend(combo.iter().cloned());
+            result.push(v);
+        }
+    }
+    result
 }
 
 fn build_candidate_sql(sq: &SearchQuery) -> String {
@@ -476,7 +448,21 @@ pub fn search_with_embedder(
     }
 
     let now_ms = resolve_now_ms(opts)?;
-    let sq = build_search_query(conn, query, opts, now_ms);
+    let matched = match prepare_match_query(conn, query, "messages_vocab") {
+        Ok(m) => m,
+        Err(SanitizeError::EmptyInput | SanitizeError::NoSearchableTerms) => {
+            debug!(%query, "query produced no searchable terms");
+            return Ok(Vec::new());
+        }
+    };
+    // `clean_for_trigram` returns an empty string when every vocab-expanded
+    // term is sub-trigram (<3 chars) and no fixed terms remain. Bail before
+    // passing an empty query to FTS5.
+    let fts_query = clean_for_trigram(matched.as_str());
+    if fts_query.is_empty() {
+        return Ok(Vec::new());
+    }
+    let sq = build_search_query(&fts_query, opts, now_ms);
     let fts_ranked = find_candidate_sessions(conn, &sq)?;
 
     if let Some(embedder) = embedder
@@ -932,49 +918,6 @@ mod tests {
     }
 
     #[test]
-    fn test_sanitize_fts_query() {
-        for (input, expected) in [
-            // Colons → quoted
-            ("role:admin", "\"role:admin\""),
-            ("foo role:user bar", "foo \"role:user\" bar"),
-            // Passthrough
-            ("hello world", "hello world"),
-            ("AND OR NOT", "AND OR NOT"),
-            // Already-quoted preserved
-            ("\"role:admin\"", "\"role:admin\""),
-            // Prefix operators stripped
-            ("^hello world", "hello world"),
-            ("^foo ^bar", "foo bar"),
-            ("^", ""),
-            ("+required term", "required term"),
-            ("-excluded term", "excluded term"),
-            ("keep -this", "keep this"),
-            // NEAR filtered
-            ("NEAR(a b)", "b"),
-            ("hello NEAR(a b) world", "hello b world"),
-            ("hello NEAR/3 world", "hello world"),
-            ("near(x y)", "y"),
-            ("Near/2 test", "test"),
-            // Internal hyphens → quoted (prevents FTS5 NOT interpretation)
-            ("mlx-rs embedding", "\"mlx-rs\" embedding"),
-            ("state-of-the-art", "\"state-of-the-art\""),
-            ("\"mlx-rs\"", "\"mlx-rs\""),
-            // Slash-containing tokens → quoted (prevents FTS5 syntax error)
-            ("/challenge", "\"/challenge\""),
-            ("use /foo today", "use \"/foo\" today"),
-            ("path/to/file", "\"path/to/file\""),
-            // Bare slashes have no alphanumerics → dropped
-            ("/", ""),
-            ("//", ""),
-            // Quote balancing
-            ("\"unbalanced", "\"unbalanced\""),
-            ("\"balanced\"", "\"balanced\""),
-        ] {
-            assert_eq!(sanitize_fts_query(input), expected, "input: {input:?}");
-        }
-    }
-
-    #[test]
     fn test_index_then_search_roundtrip() {
         use crate::indexer::{IndexOptions, index_from_dirs};
 
@@ -1020,10 +963,11 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].session.session_id, "sess-beta");
 
-        // Project filter — only alpha
+        // Project filter — alpha-only. rurico quotes FTS5 operators as literal
+        // terms, so test each side separately instead of a single OR query.
         let results = search(
             &conn,
-            "algorithm OR authentication",
+            "authentication",
             &SearchOptions {
                 project: Some("/home/me/alpha".to_owned()),
                 ..Default::default()
@@ -1032,6 +976,20 @@ mod tests {
         .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].session.project, "/home/me/alpha");
+
+        let results = search(
+            &conn,
+            "algorithm",
+            &SearchOptions {
+                project: Some("/home/me/alpha".to_owned()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            results.is_empty(),
+            "algorithm lives in beta; alpha filter should exclude it"
+        );
 
         let stats2 = index_from_dirs(
             &mut conn,
@@ -1186,83 +1144,6 @@ mod tests {
         assert_eq!(results[0].session.session_id, "s1");
     }
 
-    fn setup_vocab_db() -> (tempfile::TempDir, Connection) {
-        let (dir, conn) = setup_test_db();
-        insert_session(&conn, "s1", "claude", "/p", 1000);
-        insert_message(&conn, "s1", "user", "go language tutorial");
-        insert_message(&conn, "s1", "assistant", "golang guide here");
-        (dir, conn)
-    }
-
-    #[test]
-    fn test_expand_long_terms_passthrough() {
-        let (_dir, conn) = setup_vocab_db();
-        let result = expand_short_terms(&conn, "language tutorial");
-        assert_eq!(result, "language tutorial");
-    }
-
-    #[test]
-    fn test_expand_fts_operators_passthrough() {
-        let (_dir, conn) = setup_vocab_db();
-        let result = expand_short_terms(&conn, "foo AND bar");
-        assert_eq!(result, "foo AND bar");
-    }
-
-    #[test]
-    fn test_expand_short_term_with_vocab_match() {
-        let (_dir, conn) = setup_vocab_db();
-        let result = expand_short_terms(&conn, "go");
-        assert!(
-            result.starts_with('(') && result.ends_with(')'),
-            "short term should be expanded to OR-group: {result}"
-        );
-        assert!(result != "go", "should not be the original short term");
-    }
-
-    #[test]
-    fn test_expand_short_term_no_vocab_match() {
-        let (_dir, conn) = setup_vocab_db();
-        let result = expand_short_terms(&conn, "zz");
-        assert_eq!(result, "zz");
-    }
-
-    #[test]
-    fn test_expand_mixed_short_and_long_terms() {
-        let (_dir, conn) = setup_vocab_db();
-        let result = expand_short_terms(&conn, "go tutorial");
-        // If "go" expands to an OR-group, explicit AND should be inserted
-        if result.contains("OR") {
-            assert!(
-                result.contains(" AND "),
-                "should have explicit AND between OR-group and plain term: {result}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_expand_empty_input() {
-        let (_dir, conn) = setup_vocab_db();
-        let result = expand_short_terms(&conn, "");
-        assert_eq!(result, "");
-    }
-
-    #[test]
-    fn test_expand_short_term_filters_special_char_trigrams() {
-        let (_dir, conn) = setup_test_db();
-        insert_session(&conn, "s1", "claude", "/p", 1000);
-        // Colons produce trigrams like "go:" which must be filtered by is_alphanumeric
-        insert_message(&conn, "s1", "user", "go:run go:test go:build go:vet");
-
-        let result = expand_short_terms(&conn, "go");
-        if result.starts_with('(') {
-            assert!(
-                !result.contains(':'),
-                "special-char trigrams should be filtered: {result}"
-            );
-        }
-        assert!(search(&conn, "go", &SearchOptions::default()).is_ok());
-    }
-
     #[test]
     fn test_search_cjk_short_term_with_special_chars() {
         // The actual bug scenario: 2-char CJK term where vocab contains
@@ -1289,5 +1170,46 @@ mod tests {
         assert_eq!(escape_like("a_b"), "a\\_b");
         assert_eq!(escape_like("c:\\path"), "c:\\\\path");
         assert_eq!(escape_like("%_\\"), "\\%\\_\\\\");
+    }
+
+    #[test]
+    fn test_clean_for_trigram_distributes_or_groups() {
+        // Control chars removed + sub-trigram dropped + distributed
+        assert_eq!(
+            clean_for_trigram("(\"認証の\" OR \"認証\n\" OR \"認証フ\") \"フロー\""),
+            "\"認証の\" \"フロー\" OR \"認証フ\" \"フロー\""
+        );
+        // Single-element group + fixed term → distributed
+        assert_eq!(clean_for_trigram("\"std\" (\"ioの\")"), "\"ioの\" \"std\"");
+        // Multi-element group + fixed term → distributed
+        assert_eq!(
+            clean_for_trigram("(\"abc\" OR \"def\") \"ghi\""),
+            "\"abc\" \"ghi\" OR \"def\" \"ghi\""
+        );
+        // No parens → unchanged
+        assert_eq!(clean_for_trigram("\"hello\""), "\"hello\"");
+        // Single group, no fixed terms → just OR
+        assert_eq!(
+            clean_for_trigram("(\"abc\" OR \"def\")"),
+            "\"abc\" OR \"def\""
+        );
+        // Multiple OR groups → cross-product
+        assert_eq!(
+            clean_for_trigram("(\"a01\" OR \"a02\") (\"b01\" OR \"b02\")"),
+            "\"a01\" \"b01\" OR \"a01\" \"b02\" OR \"a02\" \"b01\" OR \"a02\" \"b02\""
+        );
+        // Multiple OR groups + fixed term
+        assert_eq!(
+            clean_for_trigram("(\"a01\" OR \"a02\") \"xyz\" (\"b01\" OR \"b02\")"),
+            "\"a01\" \"b01\" \"xyz\" OR \"a01\" \"b02\" \"xyz\" OR \"a02\" \"b01\" \"xyz\" OR \"a02\" \"b02\" \"xyz\""
+        );
+    }
+
+    #[test]
+    fn test_clean_for_trigram_empties_all_sub_trigram() {
+        // All terms in the only OR-group are sub-trigram (<3 chars);
+        // parse_fts_segments filters them out, leaving no fixed terms →
+        // empty output. The empty-guard in search_with_embedder relies on this.
+        assert_eq!(clean_for_trigram("(\"ab\" OR \"cd\")"), "");
     }
 }


### PR DESCRIPTION
## 概要

FTS クエリのサニタイズ（`sanitize_fts_query`）と CJK 短単語の vocab 展開（`expand_short_terms`）を recall 内のローカル実装から rurico へ委譲する。ローカルコードを約 130 行削除し、net -72 行。

Closes #13

## 変更内容

### 依存関係の更新

- rurico: `bc2ad90` → `e83581c`（rurico#38 マージ、`prepare_match_query` API の破壊的変更を含む）
- amici: `ae6ed39` → `2a8c734`（amici#11 マージ、dep graph 内の rurico バージョンを一本化するための rev バンプ）

### 削除

- `sanitize_fts_query` と `expand_short_terms` の実装（〜130 行）
- 8 件の廃止テスト（`test_sanitize_fts_query` + 7 件の `test_expand_*`）

### 追加

- トライグラム後処理ヘルパー 3 件（`clean_for_trigram`、`parse_fts_segments`、`cross_product`）を sae から移植
- 上記に対するリグレッションテスト 2 件
- これらのヘルパーは形状が固まり次第 rurico への昇格候補とする

## 設計判断

### トライグラムヘルパーのローカル配置

sae から複製した理由は、API の形状がまだ安定していないため。形状が固まり次第 rurico へ昇格させることをコメントに記載済み。

### `parse_fts_segments` の入力契約

doc コメントで前提条件を明示（rurico が出力した sanitized string を受け取ること）。呼び出し側の想定外使用を防ぐ。

## 挙動の変化

### FTS5 演算子（AND/OR/NOT）

rurico ADR 0001 に従い、AND/OR/NOT はリテラル語として扱われるようになった（意味的 OR はハイブリッドモードのベクトル検索が担う）。これは受け入れ済みのトレードオフ。

旧テスト `test_index_then_search_roundtrip` の OR アサーションを廃止し、プロジェクトフィルタのアサーション 2 件（positive + negative）に置き換えた。

### CJK 短単語展開の修正

rurico が `fts_chunks_vocab` をハードコードしていたため、`messages_vocab` に対する CJK 短単語（1〜2 文字）の vocab 展開がサイレントに壊れていた。委譲後は正しく動作する。

## テスト方法

```bash
cargo test
```

- 既存テスト: 全件パス（106 passed）
- 追加リグレッション: `test_clean_for_trigram_*` 2 件がパスすることを確認

## 破壊的変更

なし（公開 API への影響なし）