### PR TITLE
session filter の内部実装を amici filter helper family に置換

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use amici::cli::{
 use amici::logging::init_subscriber;
 use amici::model::download_and_verify_model;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
+use amici::storage::filter::escape_like;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use rurico::embed::{Embed, ModelId, cached_artifacts};
@@ -360,7 +361,7 @@ fn show_session(
         "SELECT session_id, source, file_path, project, slug, timestamp \
          FROM sessions WHERE session_id LIKE ?1 ESCAPE '\\' ORDER BY session_id",
     )?;
-    let pattern = format!("{}%", search::escape_like(session_id));
+    let pattern = format!("{}%", escape_like(session_id));
     let matches: Vec<parser::SessionData> = stmt
         .query_map([&pattern], |row| {
             let source_str: String = row.get(1)?;

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,12 +1,16 @@
 use std::collections::HashMap;
+use std::slice;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use amici::storage::filter::{
+    append_eq_filter, append_like_prefix_filter, append_timestamp_cutoff_filter,
+};
 use amici::storage::{anon_placeholders, fts::clean_for_trigram};
 use anyhow::{Context, Result};
 use rurico::embed::Embed;
 use rurico::storage::{SanitizeError, f32_as_bytes, prepare_match_query, rrf_merge};
 use rusqlite::Connection;
-use rusqlite::types::{ToSql, ToSqlOutput};
+use rusqlite::types::ToSql;
 use tracing::{debug, warn};
 
 use crate::date::MS_PER_DAY;
@@ -40,76 +44,50 @@ impl Default for SearchOptions {
     }
 }
 
-enum Param {
-    Str(String),
-    Int(i64),
-}
-
-impl ToSql for Param {
-    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
-        match self {
-            Param::Str(s) => s.to_sql(),
-            Param::Int(i) => i.to_sql(),
-        }
-    }
-}
-
-/// Escape LIKE metacharacters (`%`, `_`, `\`) for use with `ESCAPE '\'`.
-pub(crate) fn escape_like(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_")
-}
-
 /// Append ` AND {column} IN (...)` to `sql` and push matching params.
 ///
 /// `column` lets FTS pass `"session_id"` and vec pass `"c.session_id"` — both
 /// paths emit identical filter SQL, keeping yomu #103's single-source strategy.
 /// `&'static str` restricts `column` to compile-time literals so runtime input
 /// cannot reach the SQL string (matches amici filter helper convention).
+///
+/// Precondition: `sql` ends inside an open WHERE clause — callers anchor with
+/// `MATCH ?` (FTS path) or a trailing `WHERE 1 = 1` (vec path).
 fn append_session_filter(
     sql: &mut String,
-    params: &mut Vec<Param>,
+    params: &mut Vec<Box<dyn ToSql>>,
     column: &'static str,
     opts: &SearchOptions,
     now_ms: i64,
 ) {
-    let mut conditions = Vec::new();
-    if let Some(ref project) = opts.project {
-        let escaped = escape_like(project);
-        conditions.push("s2.project LIKE ? || '%' ESCAPE '\\'".to_owned());
-        params.push(Param::Str(escaped));
-    }
-    if let Some(days) = opts.days {
-        let cutoff = now_ms - days * MS_PER_DAY;
-        conditions.push("s2.timestamp >= ?".to_owned());
-        params.push(Param::Int(cutoff));
-    }
-    if let Some(source) = opts.source {
-        conditions.push("s2.source = ?".to_owned());
-        params.push(Param::Str(source.as_str().to_owned()));
-    }
-    if conditions.is_empty() {
+    if opts.project.is_none() && opts.days.is_none() && opts.source.is_none() {
         return;
     }
-    sql.push_str(&format!(
-        " AND {column} IN (SELECT s2.session_id FROM sessions s2 WHERE {})",
-        conditions.join(" AND ")
-    ));
+    sql.push_str(" AND ");
+    sql.push_str(column);
+    sql.push_str(" IN (SELECT s2.session_id FROM sessions s2 WHERE 1 = 1");
+    if let Some(ref project) = opts.project {
+        append_like_prefix_filter(sql, params, "s2.project", slice::from_ref(project));
+    }
+    let cutoff = opts.days.map(|d| now_ms - d * MS_PER_DAY);
+    append_timestamp_cutoff_filter(sql, params, "s2.timestamp", cutoff);
+    let source_str = opts.source.as_ref().map(Source::as_str);
+    append_eq_filter(sql, params, "s2.source", source_str);
+    sql.push(')');
 }
 
 fn build_fts_candidate_query(
     fts_query: &str,
     opts: &SearchOptions,
     now_ms: i64,
-) -> (String, Vec<Param>) {
+) -> (String, Vec<Box<dyn ToSql>>) {
     let mut sql =
         "SELECT session_id, MIN(rank) as best_rank FROM messages WHERE messages MATCH ?".to_owned();
-    let mut params = vec![Param::Str(fts_query.to_owned())];
+    let mut params: Vec<Box<dyn ToSql>> = vec![Box::new(fts_query.to_owned())];
     append_session_filter(&mut sql, &mut params, "session_id", opts, now_ms);
     sql.push_str(" GROUP BY session_id ORDER BY best_rank LIMIT ?");
     let candidate_limit = opts.limit * 3;
-    params.push(Param::Int(candidate_limit as i64));
+    params.push(Box::new(candidate_limit as i64));
     (sql, params)
 }
 
@@ -120,7 +98,7 @@ fn find_candidate_sessions(
     now_ms: i64,
 ) -> Result<Vec<(String, f64)>> {
     let (sql, params) = build_fts_candidate_query(fts_query, opts, now_ms);
-    let refs: Vec<&dyn ToSql> = params.iter().map(|p| p as &dyn ToSql).collect();
+    let refs: Vec<&dyn ToSql> = params.iter().map(AsRef::as_ref).collect();
     debug_assert_eq!(
         refs.len(),
         sql.matches('?').count(),
@@ -339,7 +317,7 @@ fn vec_search(
          ) v ON c.id = v.chunk_id \
          WHERE 1 = 1",
     );
-    let mut filter_params: Vec<Param> = Vec::new();
+    let mut filter_params: Vec<Box<dyn ToSql>> = Vec::new();
     append_session_filter(&mut sql, &mut filter_params, "c.session_id", opts, now_ms);
     sql.push_str(" GROUP BY c.session_id ORDER BY MIN(v.distance)");
 
@@ -348,7 +326,7 @@ fn vec_search(
     refs.push(&embedding_bytes);
     refs.push(&limit_i64);
     for p in &filter_params {
-        refs.push(p as &dyn ToSql);
+        refs.push(p.as_ref());
     }
     debug_assert_eq!(
         refs.len(),
@@ -1297,14 +1275,5 @@ mod tests {
         let results = search(&conn, "ディレクトリ整理 方針", &SearchOptions::default())
             .expect("CJK short term + long term should not cause FTS5 error");
         assert_eq!(results.len(), 1);
-    }
-
-    #[test]
-    fn test_escape_like_basic() {
-        assert_eq!(escape_like("hello"), "hello");
-        assert_eq!(escape_like("100%"), "100\\%");
-        assert_eq!(escape_like("a_b"), "a\\_b");
-        assert_eq!(escape_like("c:\\path"), "c:\\\\path");
-        assert_eq!(escape_like("%_\\"), "\\%\\_\\\\");
     }
 }


### PR DESCRIPTION
## 概要・目的

`build_session_filter` 内の自前実装（`Param` enum、`escape_like`、条件文字列生成）を、amici PR #19 で集約された `append_*` filter helper family に全面置換する。

recall 側に重複していたエスケープロジックとパラメータ型定義を除去し、filter 構築の単一責任を amici 側に集約することで、将来の条件追加時に recall が手を入れる箇所をゼロにする。

## 変更内容

- `Param { Str, Int }` enum と `impl ToSql` を削除 — `Vec<Box<dyn ToSql>>` 直渡しに統一し、型の二重管理を解消
- `escape_like` 関数と `test_escape_like_basic` テストを削除 — 同等カバレッジは amici 側 T-018〜T-020 で保証済み
- `append_session_filter` の 3 条件を amici helper に委譲:
  - project (LIKE prefix) → `append_like_prefix_filter`
  - days (timestamp cutoff) → `append_timestamp_cutoff_filter`
  - source (eq) → `append_eq_filter`
- 中間 String `sub_sql` を排除し `sql` に直接 `push_str` — 毎呼び出しの不要な String alloc を削除 (EFF-001)
- `append_session_filter` に precondition doc を追記
- `src/main.rs`: `search::escape_like` → `amici::storage::filter::escape_like` にインポート切替

## スコープ

- **含まない**: `Vec<Box<dyn ToSql>>` → `Vec<&dyn ToSql>` 変換による毎クエリ alloc の排除 (EFF-002、`rusqlite::params_from_iter` で対応可能、影響小につき別 issue 化)

## 設計判断

- `Param` enum の廃止と filter 委譲を 1 コミットにまとめた — 中間状態（Param だけ廃止、filter はまだ自前）を残すと型整合が壊れるため、原子的に置換した
- `escape_like` テストを削除したのはテスト責務の移動であり、カバレッジの欠落ではない — amici 側で既にエッジケースまでカバーされている

## テスト方法

- [ ] `cargo test` — 108 passed / 0 failed（`test_escape_like_basic` 削除分の -1 は意図的）
- [ ] `cargo clippy --all-targets -- -D warnings` — 警告なし
- [ ] `cargo fmt --check` — 差分なし
- [ ] session filter を伴う検索クエリ（project / days / source 各条件）が正常に絞り込まれること

## 関連

- Closes #46
- Closes #43
- amici PR #19: https://github.com/thkt/amici/pull/19