### PR TITLE
fix(ci): #89 follow-ups — label-from-issue labeler 是正 + release linux ターゲット削除

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,5 +1,5 @@
 # Maps Issue Forms dropdown selections to labels.
-# See https://github.com/stefanbuck/advanced-issue-labeler for syntax.
+# See https://github.com/redhat-plumbers-in-action/advanced-issue-labeler for syntax.
 #
 # Per-repo extension: target repos can append additional `policy` entries
 # (e.g. for area:* labels) by editing this file directly. The shared base
@@ -9,12 +9,12 @@ policy:
       - bug.yml
       - feature.yml
     section:
-      - id: priority
-        block-list:
-          - high
-          - medium
-          - low
+      - id: [priority]
+        block-list: []
         label:
-          - priority:high
-          - priority:medium
-          - priority:low
+          - name: 'priority:high'
+            keys: ['high']
+          - name: 'priority:medium'
+            keys: ['medium']
+          - name: 'priority:low'
+            keys: ['low']

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -7,22 +7,46 @@ on:
       - edited
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Apply priority labels
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Parse bug.yml
+        id: parse-bug
         uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
         with:
+          template-path: .github/ISSUE_TEMPLATE/bug.yml
+        continue-on-error: true
+
+      - name: Apply labels for bug
+        if: steps.parse-bug.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
+        with:
+          issue-form: ${{ steps.parse-bug.outputs.jsonString }}
           template: bug.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Apply priority labels (feature)
+      - name: Parse feature.yml
+        id: parse-feature
         uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
         with:
+          template-path: .github/ISSUE_TEMPLATE/feature.yml
+        continue-on-error: true
+
+      - name: Apply labels for feature
+        if: steps.parse-feature.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
+        with:
+          issue-form: ${{ steps.parse-feature.outputs.jsonString }}
           template: feature.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             name: recall-aarch64-apple-darwin
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            name: recall-x86_64-unknown-linux-gnu
 
     runs-on: ${{ matrix.os }}
 
@@ -45,12 +42,7 @@ jobs:
       - name: Build
         env:
           TARGET: ${{ matrix.target }}
-        run: |
-          if [ "$TARGET" = "aarch64-apple-darwin" ]; then
-            cargo build --release --target "$TARGET" --no-default-features --features mlx
-          else
-            cargo build --release --target "$TARGET" --no-default-features --features candle
-          fi
+        run: cargo build --release --target "$TARGET"
 
       - name: Package
         env:
@@ -59,18 +51,14 @@ jobs:
         run: |
           cp "target/$TARGET/release/recall" recall
           chmod +x recall
-          if [ "$TARGET" = "aarch64-apple-darwin" ]; then
-            METALLIB=$(find "target/$TARGET/release/build" -path "*/mlx-sys-*/out/build/lib/mlx.metallib" | head -1)
-            if [ -z "$METALLIB" ]; then
-              echo "::error::mlx.metallib not found in build artifacts"
-              exit 1
-            fi
-            cp "$METALLIB" mlx.metallib
-            echo "Bundling mlx.metallib ($(du -h mlx.metallib | cut -f1))"
-            tar czf "$NAME.tar.gz" recall mlx.metallib
-          else
-            tar czf "$NAME.tar.gz" recall
+          METALLIB=$(find "target/$TARGET/release/build" -path "*/mlx-sys-*/out/build/lib/mlx.metallib" | head -1)
+          if [ -z "$METALLIB" ]; then
+            echo "::error::mlx.metallib not found in build artifacts"
+            exit 1
           fi
+          cp "$METALLIB" mlx.metallib
+          echo "Bundling mlx.metallib ($(du -h mlx.metallib | cut -f1))"
+          tar czf "$NAME.tar.gz" recall mlx.metallib
 
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -147,23 +135,42 @@ jobs:
             exit 1
           fi
 
-          # Calculate checksums
+          # Calculate checksum (Apple Silicon only; mlx backend requires Metal)
           SHA_AARCH64_DARWIN=$(sha256sum artifacts/recall-aarch64-apple-darwin/recall-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)
-          SHA_X86_64_LINUX=$(sha256sum artifacts/recall-x86_64-unknown-linux-gnu/recall-x86_64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)
 
           # Verify macOS archive contains mlx.metallib
           tar tzf artifacts/recall-aarch64-apple-darwin/recall-aarch64-apple-darwin.tar.gz | grep -q mlx.metallib \
             || { echo "::error::mlx.metallib missing from macOS archive"; exit 1; }
 
-          # Ensure Formula directory exists
+          # Generate Formula inline (self-contained; no tap-side template dependency)
           mkdir -p Formula
+          cat > Formula/recall.rb << FORMULA
+          class Recall < Formula
+            desc "Search past Claude Code and Codex sessions with semantic search"
+            homepage "https://github.com/thkt/recall"
+            version "${VERSION}"
+            license "MIT"
 
-          # Update Formula using sed on existing template
-          sed -e "s/__VERSION__/$VERSION/g" \
-              -e "s/__TAG__/$TAG/g" \
-              -e "s/__SHA_AARCH64_DARWIN__/$SHA_AARCH64_DARWIN/g" \
-              -e "s/__SHA_X86_64_LINUX__/$SHA_X86_64_LINUX/g" \
-              Formula/recall.rb.template > Formula/recall.rb
+            on_macos do
+              on_arm do
+                url "https://github.com/thkt/recall/releases/download/${TAG}/recall-aarch64-apple-darwin.tar.gz"
+                sha256 "${SHA_AARCH64_DARWIN}"
+              end
+            end
+
+            def install
+              libexec.install "recall", "mlx.metallib"
+              bin.install_symlink libexec/"recall"
+            end
+
+            test do
+              assert_match "recall", shell_output("#{bin}/recall --help")
+            end
+          end
+          FORMULA
+
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' Formula/recall.rb
 
       - name: Commit and push
         env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,15 +3,15 @@ rules:
     ignore:
       # release.yml: "Checkout homebrew-tap" step in update-homebrew job.
       # HOMEBREW_TAP_TOKEN must persist for the subsequent git push to homebrew-tap.
-      - release.yml:122
+      - release.yml:110
   cache-poisoning:
     ignore:
       # release.yml: "Cache Cargo" step in build job.
       # Release workflow runs on tag push only; no PR-driven cache injection path
       # exists for poisoning to reach release artifacts.
-      - release.yml:41
+      - release.yml:38
   superfluous-actions:
     ignore:
       # release.yml: "Create Release" step (softprops/action-gh-release).
       # Retained for the generate_release_notes feature; gh CLI lacks an equivalent.
-      - release.yml:109
+      - release.yml:97


### PR DESCRIPTION
## 概要

PR #89（yomu CI hardening 横展開）のフォローアップ 2 件。いずれも調査で「単なる構造の古さ」でなく**機能が壊れている / 次の release を止める**潜在バグと判明したため修正。

## fix(ci): label-from-issue labeler を yomu に揃える（#94）

recall の旧構成は `github-issue-parser`（parse 専用）のみを呼び、ラベルを付与する `advanced-issue-labeler` step が欠落していた。さらに `.github/advanced-issue-labeler.yml` が `block-list: [high, medium, low]` で**全 priority をブロックする壊れた stefanbuck 旧式 schema** で、優先度ラベル自動付与が no-op だった。

- `label-from-issue.yml`: `parse -> redhat-plumbers advanced-issue-labeler` の 2-step 構成に是正（yomu と一致）。`contents: read` + `timeout-minutes: 5` 追加
- `advanced-issue-labeler.yml`: redhat-plumbers 形式（`id: [priority]` + 空 `block-list` + `name`/`keys` マッピング）に是正
- recall の `bug.yml` / `feature.yml` は `id: priority` + options `high/medium/low` で yomu の keys と完全一致済み

## fix(release): ビルド不能な linux ターゲット削除 + homebrew formula を inline 化（#95）

`candle` backend は `c5c4993` で削除済みで、現 `rurico` は `mlx-rs`/`mlx-sys` を無条件依存する。release.yml の `--no-default-features --features mlx/candle` は**存在しない feature を参照**しており、次の tag push で build step が破綻する状態だった（`cargo tree --features mlx`/`candle` がいずれも `does not contain this feature` で失敗、`Cargo.lock` に candle 0 件）。`mlx-sys` は Apple Metal 依存のため x86_64-linux はそもそもビルド不能。

- build matrix: `x86_64-unknown-linux-gnu` を削除（`aarch64-apple-darwin` 単一、yomu と一致）
- build step: plain `cargo build --release`（feature flag 撤去。default feature set は clippy --all-targets + nextest 108 passed で compile 実証済み）
- package: `TARGET` 分岐を撤去。`mlx.metallib` 厳格チェックは維持（`b8e5004` の回帰防止）
- update-homebrew: tap テンプレ依存を廃し yomu 形式の inline heredoc に切替。recall 固有の `libexec` install は維持
- `zizmor.yml`: release.yml の行ズレに伴い ignore アンカーを更新（artipacked 122->110 / cache-poisoning 41->38 / superfluous-actions 109->97）

## 補足

- `thkt/homebrew-tap` の `recall.rb.template`（`on_linux` ブロック付き）は inline 化により **vestigial（未使用）** になる。別 repo のため本 PR では削除しない。tap 側のクリーンアップは任意のフォローアップ
- `.claude/OUTCOME.md` の candle CPU fallback 記述（Non-goals / Constraints）はローカルで Apple Silicon 専用に更新済みだが、recall は `.claude/` を gitignore しているため本 PR には含まれない（version-control 対象外）

## テスト

- [x] `zizmor .github/workflows/` → `No findings to report (3 ignored, 17 suppressed)`
- [x] homebrew formula 生成を再現 → `ruby -c` で `Syntax OK`
- [x] label-from-issue.yml / advanced-issue-labeler.yml が yomu と差分なし（checkout コメント `# v6.0.2` のみ）
- [ ] CI（test / security）green
- [ ] merge 後: issue form 経由で bug/feature 作成 → priority ラベル自動付与を確認（#94）
- [ ] 次の tag push で release green（#95）

Closes #94
Closes #95
