### PR TITLE
refactor(cli)!: rebuild コマンド分離 + embed 未index メッセージ修正 (#81, #93)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -90,8 +90,8 @@ recall search "auth" --no-embed                                    # post-search
 ### インデックス
 
 ```sh
-recall index            # parse + chunk（モデル呼び出しなし）
-recall index --force    # 全件再構築
+recall index            # 新規セッションログを解析 + チャンク化（差分、モデル呼び出しなし）
+recall rebuild          # インデックスを破棄して全件再構築
 ```
 
 ### Embedding
@@ -154,7 +154,8 @@ src/
 
 | 操作                                    | 所要時間                                   |
 | --------------------------------------- | ------------------------------------------ |
-| `recall index`（6kファイル）            | 約0.5秒（差分）、約4分（全件再構築）       |
+| `recall index`（6kファイル）            | 約0.5秒（差分）                            |
+| `recall rebuild`（6kファイル）          | 約4分（全件再構築）                        |
 | `recall search`                         | 約2秒（embedding込み）、即座（--no-embed） |
 | `recall embed`（28kチャンク）           | 約11分（M3, batch=128）                    |
 | embeddingスループット                   | 約45 chunks/sec（M3 + MLX）                |

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Supports [FTS5 query syntax](https://www.sqlite.org/fts5.html#full_text_query_sy
 ### Index
 
 ```sh
-recall index            # parse + chunk session logs (no model calls)
-recall index --force    # full rebuild
+recall index            # parse + chunk new session logs (incremental, no model calls)
+recall rebuild          # drop and rebuild the full index from scratch
 ```
 
 ### Embed
@@ -156,7 +156,8 @@ Single binary. SQLite, mlx-rs, and sqlite-vec are statically linked.
 
 | Operation                           | Time                                       |
 | ----------------------------------- | ------------------------------------------ |
-| `recall index` (6k files)           | ~0.5s (incremental), ~4min (full rebuild)  |
+| `recall index` (6k files)           | ~0.5s (incremental)                        |
+| `recall rebuild` (6k files)         | ~4min (full rebuild)                       |
 | `recall search`                     | ~2s (with embedding), instant (--no-embed) |
 | `recall embed` (28k chunks)         | ~11 min (M3, batch=128)                    |
 | Embedding throughput                | ~45 chunks/sec (M3 + MLX)                  |

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,12 +56,10 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Parse and chunk session logs. No model calls.
-    Index {
-        /// Force full rebuild
-        #[arg(long)]
-        force: bool,
-    },
+    /// Parse and chunk new session logs (incremental). No model calls.
+    Index,
+    /// Drop the index and rebuild from all sessions. No model calls.
+    Rebuild,
     /// Embed pending chunks for semantic search.
     Embed,
     /// Manage the embedding model.
@@ -178,7 +176,17 @@ fn try_load_embedder_cached() -> Option<Arc<dyn Embed>> {
 
 // -- Subcommands --
 
-fn run_index(force: bool, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_index(db_path: &Option<PathBuf>) -> Result<()> {
+    index_and_report(db_path, false)
+}
+
+fn run_rebuild(db_path: &Option<PathBuf>) -> Result<()> {
+    index_and_report(db_path, true)
+}
+
+/// Shared index pipeline for `index` (incremental) and `rebuild` (full).
+/// `force` is internalized here so both entry points stay argument-free.
+fn index_and_report(db_path: &Option<PathBuf>, force: bool) -> Result<()> {
     let path = resolve_db_path(db_path)?;
     let mut conn = open_or_create_db(&path)?;
 
@@ -558,7 +566,7 @@ fn print_results(results: &[search::SearchResult]) {
 // -- Entry point --
 
 const KNOWN_SUBCOMMANDS: &[&str] = &[
-    "index", "embed", "model", "search", "show", "status", "help",
+    "index", "rebuild", "embed", "model", "search", "show", "status", "help",
 ];
 const GLOBAL_FLAGS: &[&str] = &["--verbose", "-v"];
 
@@ -577,7 +585,8 @@ fn run() -> Result<()> {
     init_subscriber(default_filter);
 
     match cli.command {
-        Some(Command::Index { force }) => run_index(force, &cli.db_path),
+        Some(Command::Index) => run_index(&cli.db_path),
+        Some(Command::Rebuild) => run_rebuild(&cli.db_path),
         Some(Command::Embed) => run_embed(&cli.db_path),
         Some(Command::Model(ModelCommand::Download)) => run_model_download(),
         Some(cmd @ Command::Search { .. }) => run_search(cmd, &cli.db_path),
@@ -696,6 +705,27 @@ mod tests {
         format_result(&mut buf, 0, &r).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert!(!output.contains("> "));
+    }
+
+    #[test]
+    fn test_rebuild_is_a_distinct_subcommand() {
+        let cli = Cli::try_parse_from(["recall", "rebuild"]).unwrap();
+        assert!(matches!(cli.command, Some(Command::Rebuild)));
+    }
+
+    #[test]
+    fn test_index_no_longer_accepts_force_flag() {
+        assert!(Cli::try_parse_from(["recall", "index", "--force"]).is_err());
+        let cli = Cli::try_parse_from(["recall", "index"]).unwrap();
+        assert!(matches!(cli.command, Some(Command::Index)));
+    }
+
+    #[test]
+    fn test_rebuild_recognized_by_shorthand_expansion() {
+        // Without `rebuild` in KNOWN_SUBCOMMANDS, `recall rebuild` would be
+        // rewritten to `search rebuild` by shorthand expansion.
+        let args: Vec<OsString> = ["recall", "rebuild"].iter().map(OsString::from).collect();
+        assert!(try_expand_shorthand(&args, KNOWN_SUBCOMMANDS, GLOBAL_FLAGS).is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,16 @@ fn index_and_report(db_path: &Option<PathBuf>, force: bool) -> Result<()> {
     Ok(())
 }
 
+/// Message shown when no chunks are pending embedding. Distinguishes
+/// "index not run yet" (no chunks at all) from "everything already embedded".
+fn embed_idle_message(total_chunks: i64) -> &'static str {
+    if total_chunks == 0 {
+        "No chunks to embed. Run `recall index` first."
+    } else {
+        "All chunks already embedded"
+    }
+}
+
 fn run_embed(db_path: &Option<PathBuf>) -> Result<()> {
     let path = resolve_db_path(db_path)?;
     let mut conn = open_or_create_db(&path)?;
@@ -235,7 +245,9 @@ fn run_embed(db_path: &Option<PathBuf>) -> Result<()> {
     )?;
 
     if pending == 0 {
-        done("All chunks already embedded");
+        let total_chunks: i64 =
+            conn.query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))?;
+        done(embed_idle_message(total_chunks));
         return Ok(());
     }
 
@@ -705,6 +717,15 @@ mod tests {
         format_result(&mut buf, 0, &r).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert!(!output.contains("> "));
+    }
+
+    #[test]
+    fn test_embed_idle_message_distinguishes_unindexed_from_embedded() {
+        assert_eq!(
+            embed_idle_message(0),
+            "No chunks to embed. Run `recall index` first."
+        );
+        assert_eq!(embed_idle_message(5), "All chunks already embedded");
     }
 
     #[test]


### PR DESCRIPTION
## 概要

CLI 整列 first delivery。性質の違う 2 件を 1 PR・2 コミットで。

- **#81 (破壊的変更)**: `recall index --force` を廃止し `recall rebuild` 別コマンドに分離（yomu の incremental/rebuild 整列、sae も追随予定）。`force` は共通ヘルパー `index_and_report` に内部化し、`run_index`/`run_rebuild` は引数なしラッパー。
- **#93**: `recall index` 前に `recall embed` したとき「All chunks already embedded」と誤表示する問題を修正。未 index（chunk 0 件）と embed 済みを区別し、`recall index` 実行を案内。

## 破壊的変更

`recall index --force` は削除。全件再構築は `recall rebuild` を使用。

## 補足

実装中に `Command::Rebuild` 追加時の `KNOWN_SUBCOMMANDS` 登録漏れがあり、`recall rebuild` が shorthand expansion で `recall search rebuild` に化けて機能しないバグを /polish (Codex) が捕捉。`KNOWN_SUBCOMMANDS` に追加 + 回帰テスト `test_rebuild_recognized_by_shorthand_expansion` を追加済み。

## 検証

- `cargo test`: 112 passed / `cargo clippy -- -D warnings`: clean
- 各コミット単独でビルド可（#81 時点 111、#93 適用後 112）
- 実機: `recall --help` に index/rebuild 分離表示、`recall rebuild --help` 正常、`recall index --force` 拒否

Closes #81, #93