### PR TITLE
chore(deps): bump amici b545722 + rurico a573655 と API 追従 (#78, #79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,10 +34,16 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=dddbef0#dddbef0d04253d7207d9f2ee8a82184b8387f1d5"
+source = "git+https://github.com/thkt/amici?rev=b545722#b54572260e8a7685c7503284de27eec0585dfd28"
 dependencies = [
+ "bytemuck",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rurico",
  "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]
@@ -220,6 +226,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "clang-sys"
@@ -432,6 +449,12 @@ checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
 
 [[package]]
 name = "darling"
@@ -859,6 +882,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -964,7 +988,7 @@ dependencies = [
  "log",
  "native-tls",
  "num_cpus",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -1839,8 +1863,19 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1850,7 +1885,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1861,6 +1906,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -1899,6 +1950,7 @@ version = "0.7.0"
 dependencies = [
  "amici",
  "anyhow",
+ "bytemuck",
  "clap",
  "dirs",
  "hex",
@@ -2031,11 +2083,10 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
+source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
 dependencies = [
  "bytemuck",
  "hf-hub",
- "log",
  "mlx-rs",
  "rurico-ffi",
  "rusqlite",
@@ -2043,12 +2094,14 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokenizers",
+ "tracing",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
+source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2514,14 +2567,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokenizers"
-version = "0.22.2"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -2532,7 +2600,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -2758,6 +2826,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ repository = "https://github.com/thkt/recall"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "dddbef0" }
+amici = { git = "https://github.com/thkt/amici", rev = "b545722" }
 anyhow = "1.0.102"
+bytemuck = "1"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 dirs = "6.0.0"
 hex = "0.4.3"
-rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "a573655" }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
@@ -25,8 +26,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "dddbef0", features = ["test-support"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1", features = ["test-support"] }
+amici = { git = "https://github.com/thkt/amici", rev = "b545722", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "a573655", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use rurico::embed::Embed;
 #[cfg(test)]
 use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS, EmbedError};
-use rurico::storage::f32_as_bytes;
 use rusqlite::Connection;
 use rusqlite::types::ToSql;
 use tracing::warn;
@@ -27,6 +26,12 @@ impl EmbedResult {
 }
 
 pub(crate) const EMBED_BATCH_SIZE: usize = 128;
+
+/// Reinterprets an f32 slice as its raw byte view for sqlite-vec storage.
+/// Replaces `rurico::storage::f32_as_bytes`, removed in rurico a573655 (#78).
+pub(crate) fn f32_as_bytes(v: &[f32]) -> &[u8] {
+    bytemuck::cast_slice(v)
+}
 
 fn embed_chunks(
     conn: &mut Connection,
@@ -212,9 +217,9 @@ impl Embed for MockEmbedder {
                 return Err(EmbedError::Inference("mock failure".to_owned()));
             }
         }
-        Ok(ChunkedEmbedding {
-            chunks: vec![Self::deterministic_vector(text)],
-        })
+        Ok(ChunkedEmbedding::new(vec![Self::deterministic_vector(
+            text,
+        )]))
     }
 
     fn embed_text(&self, text: &str, _prefix: &str) -> Result<Vec<f32>, EmbedError> {

--- a/src/hybrid.rs
+++ b/src/hybrid.rs
@@ -1,5 +1,7 @@
 use std::f64::consts::LN_2;
 
+use rurico::retrieval::{Candidate, CandidateSource, MergeStrategy, WeightedRrf};
+
 use crate::date::MS_PER_DAY;
 
 pub(crate) const RECENCY_HALF_LIFE_DAYS: f64 = 30.0;
@@ -33,11 +35,48 @@ pub(crate) fn apply_recency_boost(
     results.sort_by(|a, b| b.1.total_cmp(&a.1));
 }
 
+/// Merge FTS and vector ranking lists by Reciprocal Rank Fusion, keyed by
+/// session id. Adapts recall's `(session_id, score)` shape to rurico's
+/// `Candidate` / `MergedHit` and delegates to `WeightedRrf::default()`, whose
+/// score is bit-equal to the removed `rurico::storage::rrf_merge` (#79).
+/// Only list position (rank) feeds the fusion; input scores are ignored.
+pub(crate) fn rrf_merge_strings(
+    fts_hits: &[(String, f64)],
+    vec_hits: &[(String, f64)],
+) -> Vec<(String, f64)> {
+    let candidates: Vec<Candidate> = fts_hits
+        .iter()
+        .enumerate()
+        .map(|(rank, (sid, _))| Candidate {
+            source: CandidateSource::Fts,
+            doc_id: sid.clone(),
+            chunk_id: None,
+            score: 0.0,
+            rank,
+        })
+        .chain(
+            vec_hits
+                .iter()
+                .enumerate()
+                .map(|(rank, (sid, _))| Candidate {
+                    source: CandidateSource::Vector,
+                    doc_id: sid.clone(),
+                    chunk_id: None,
+                    score: 0.0,
+                    rank,
+                }),
+        )
+        .collect();
+    WeightedRrf::default()
+        .merge(&candidates)
+        .into_iter()
+        .map(|h| (h.doc_id, h.score))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-
-    use rurico::storage::rrf_merge;
 
     use super::*;
 
@@ -48,7 +87,7 @@ mod tests {
         // B at position 0 in vec list (rank=0), C at position 1 (rank=1)
         let vec: Vec<(String, f64)> = vec![("B".into(), 0.0), ("C".into(), 0.0)];
 
-        let merged = rrf_merge(&fts, &vec);
+        let merged = rrf_merge_strings(&fts, &vec);
 
         // B appears in both lists → highest score
         assert_eq!(merged[0].0, "B");
@@ -67,7 +106,7 @@ mod tests {
         let fts: Vec<(String, f64)> = vec![("A".into(), 0.0)];
         let vec: Vec<(String, f64)> = vec![];
 
-        let merged = rrf_merge(&fts, &vec);
+        let merged = rrf_merge_strings(&fts, &vec);
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].0, "A");
@@ -136,7 +175,7 @@ mod tests {
     fn test_rrf_empty_inputs() {
         let fts: Vec<(String, f64)> = vec![];
         let vec: Vec<(String, f64)> = vec![];
-        let merged = rrf_merge(&fts, &vec);
+        let merged = rrf_merge_strings(&fts, &vec);
         assert!(merged.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use amici::storage::filter::escape_like;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use rurico::embed::{Embed, ModelId, cached_artifacts};
-use rurico::model_probe::handle_probe_if_needed;
+use rurico::handle_probe_if_needed;
 use rusqlite::Connection;
 use tracing::{info, warn};
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -8,10 +8,13 @@ use amici::storage::filter::{
 use amici::storage::{anon_placeholders, fts::clean_for_trigram};
 use anyhow::{Context, Result};
 use rurico::embed::Embed;
-use rurico::storage::{SanitizeError, f32_as_bytes, prepare_match_query, rrf_merge};
+use rurico::storage::{QueryNormalizationConfig, SanitizeError, prepare_match_query};
 use rusqlite::Connection;
 use rusqlite::types::ToSql;
 use tracing::{debug, warn};
+
+use crate::embedder::f32_as_bytes;
+use crate::hybrid::rrf_merge_strings;
 
 use crate::date::MS_PER_DAY;
 use crate::hybrid::{self, RECENCY_BOOST_WEIGHT};
@@ -380,11 +383,25 @@ pub fn search_with_embedder(
     }
 
     let now_ms = resolve_now_ms(opts)?;
-    let matched = match prepare_match_query(conn, query, "messages_vocab") {
+    // Normalization disabled to stay symmetric with the index: the indexer writes
+    // raw message text into FTS (no normalize_for_fts pass), so query-side NFKC /
+    // lowercase / whitespace folding would silently miss full-width and CJK matches.
+    // Adopting normalization means normalizing both sides and re-indexing (#51).
+    let matched = match prepare_match_query(
+        conn,
+        query,
+        "messages_vocab",
+        &QueryNormalizationConfig::disabled(),
+    ) {
         Ok(m) => m,
         Err(SanitizeError::EmptyInput | SanitizeError::NoSearchableTerms) => {
             debug!(%query, "query produced no searchable terms");
             return Ok(Vec::new());
+        }
+        // A bad vocab-table name or a failed SQLite vocab lookup is a real
+        // fault, not an empty query — surface it instead of returning no hits.
+        Err(e @ (SanitizeError::InvalidVocabTable(_) | SanitizeError::VocabLookupFailed(_))) => {
+            return Err(e.into());
         }
     };
     let Some(fts_query) = clean_for_trigram(&matched) else {
@@ -416,7 +433,7 @@ pub fn search_with_embedder(
         let vec_for_rrf: Vec<(String, f64)> =
             vec_hits.iter().map(|(sid, _)| (sid.clone(), 0.0)).collect();
 
-        let mut merged = rrf_merge(&fts_hits, &vec_for_rrf);
+        let mut merged = rrf_merge_strings(&fts_hits, &vec_for_rrf);
 
         if merged.is_empty() {
             return Ok(Vec::new());


### PR DESCRIPTION
## 概要

recall の依存を Group 2(yomu / sae)と同一の amici `b545722` + rurico `a573655` に揃え、rurico a573655 の API 変更に追従する。recall だけが旧 rev(amici dddbef0 / rurico 7b739d1)で drift していた状態を解消する。

rev bump はコンパイルを通すために以下の API 変更を一括で追従する必要がある(分割不可、原子的コミット)。

## 変更内容

| 変更 | 内容 | issue |
|------|------|-------|
| `f32_as_bytes` | rurico::storage から削除 → `bytemuck::cast_slice` を内包するローカル helper(embedder.rs) | #78 |
| `rrf_merge` | rurico::storage から削除 → ローカル `rrf_merge_strings`(`(session_id, score)` を `Candidate` に詰め替え `WeightedRrf::default()` へ委譲) | #79 |
| `prepare_match_query` | 第4引数 `&QueryNormalizationConfig` 追加 → `::disabled()` を渡す(下記) | #57 (signature のみ) |
| `SanitizeError` | 新 variant `InvalidVocabTable` / `VocabLookupFailed` を空結果でなくエラーとして伝播 | |
| `handle_probe_if_needed` | rurico crate root へ移動 | |
| `ChunkedEmbedding` | `::new()` コンストラクタ経由(chunk_ids 自動生成) | |

## 正規化を `disabled()` にした理由

`prepare_match_query` の正規化 config は `default()`(NFKC + ASCII小文字化 + 空白圧縮)でなく `disabled()` を渡す。recall の indexer は FTS に生テキストを格納する(`normalize_for_fts` を通さない)ため、クエリ側だけ正規化すると非対称になり、全角・CJK クエリが既存 index に空振る(silent miss)。本 PR は挙動保存が目的なので正規化は無効化する。

正規化の採用(index 側 normalize + 既存データ再 index)は表記揺れ吸収の feature であり、#57 / #51 で別途扱う。本 PR では #57 の signature 追従と `ChunkedEmbedding::new` のみ消化し、#57 は正規化本体のため open のまま残す。

この非対称リスクは /polish の code-review + Codex が独立に検出し、`default()` → `disabled()` に修正済み。

## RRF スコア互換性

`WeightedRrf::default()` は削除された `rurico::storage::rrf_merge` と bit-equal(rurico docstring に明記)。既存の RRF テスト(`test_008_rrf_merge_both_lists` ほか)が同一スコアを assert しており、全 pass で互換を実証。

## 検証

- `cargo test`: 117 passed(RRF bit-equal 含む)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: OK
- 実 DB(5351 セッション)での検索スモーク: 正常

Closes #78
Closes #79
