### PR TITLE
ci: diff coverage gate を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,56 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  coverage:
+    # Diff coverage gate: fail when coverage of the lines this PR adds or
+    # changes drops below the threshold, so new uncovered code (pub fn /
+    # branches) cannot merge untested. No overall-percent floor (which would
+    # flag existing unreachable code); no base-vs-PR double measurement.
+    # Rationale: ported from yomu (Issue #223), THRESHOLDS.md "Coverage".
+    # Runs on macos like the test job: the rurico dependency pulls mlx-sys
+    # (MLX FFI), which needs BLAS + Apple silicon and cannot build on Linux.
+    # Mirrors the test job's default feature set so coverage matches what
+    # the tests exercise.
+    runs-on: macos-latest
+    timeout-minutes: 30
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate lcov coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
+
+      - name: Diff coverage gate (changed lines >= 95%)
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          # diff-cover is a Python tool; isolate it in a venv to avoid PEP 668
+          # (externally-managed environments) regardless of the runner's Python.
+          python3 -m venv /tmp/diff-cover-venv
+          /tmp/diff-cover-venv/bin/pip install --quiet diff-cover
+          /tmp/diff-cover-venv/bin/diff-cover lcov.info \
+            --compare-branch=origin/main \
+            --fail-under=95
+
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 docs/
 target/
 workspace/
+
+# Coverage artifacts (cargo llvm-cov)
+*.profraw
+/lcov.info


### PR DESCRIPTION
## 概要

PR の変更行カバレッジが 95% を下回ると fail する `coverage` job を CI に追加する。未テストの新規 `pub fn` / 分岐が merge されるのを防ぐ。全体 percent の floor は持たない（到達不可コードを誤検知しないため）。

yomu (#223) で本番稼働、rurico (#195) / amici (#126) / sae (#169) でも実証済みの diff coverage 方式を recall に展開。これで Tier 1 (mlx 依存・活発リポジトリ) 完了。

## 方式

- `cargo llvm-cov --lcov` でカバレッジ測定。test job が default features で回すので同じ feature set に揃え、測定対象をテストが exercise する範囲と一致させる
- `diff-cover --compare-branch=origin/main --fail-under=95` で **PR の変更行のみ**を判定
- rurico 依存が mlx-sys (BLAS + Apple silicon 必須) を引き Linux ビルド不可のため `macos-latest`（test job と同じ）
- diff-cover は PEP 668 回避のため venv に隔離
- `if: pull_request` で PR 時のみ実行

## 検証

本 PR は ci.yml / .gitignore のみ変更で **Rust 行ゼロ** → diff-cover が「変更行なし」で N/A pass する想定（ケース(a)）。未カバー行での fail 挙動は yomu (#226) / rurico (#196) の同一 invocation で実証済み。recall は単一 crate でルートパスのみのため probe は省略。

## 関連

- 移植元: yomu #223 / rurico #195 / amici #126 / sae #169
- THRESHOLDS.md "Coverage" 節
