### PR TITLE
feat(cli)!: ADR-0066 Group 2 exit code 分類と CliError 実装 (#82, #83, #26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
+thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,254 @@
+//! Exit-code classification per ADR-0066 Group 2 baseline.
+//!
+//! recall stays anyhow-based internally. `RecallError` types only the explicit
+//! failures recall raises, so a classification survives to the CLI boundary
+//! where [`classify_exit_code`] maps the anyhow error chain to a sysexits exit
+//! code (via [`amici::cli::exit_code::codes`]). This replaces the former
+//! `USER_ERROR_MARKERS` stderr-string match, which silently broke whenever a
+//! `bail!` message was reworded (#26 / #82 / #83).
+//!
+//! The ADR-0066 Group 2 baseline also defines `CANT_CREAT` (73); recall has no
+//! distinct "cannot create output" path (DB/IO failures map to `IoError`), so
+//! that class is intentionally absent until a path needs it.
+
+use std::io;
+use std::process::ExitCode;
+
+use amici::cli::exit_code::{CliError, codes};
+use amici::model::ModelDownloadError;
+use amici::model::embedder::DegradedReason;
+use rurico::storage::SanitizeError;
+
+/// sysexits-derived exit-code classes recall distinguishes (ADR-0066 Group 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ErrorCode {
+    /// Command used wrong: missing query, unresolved or ambiguous id, no index.
+    Usage,
+    /// Malformed input data: an unparseable search query.
+    DataError,
+    /// Invariant violation or programmer error.
+    Internal,
+    /// I/O or SQLite failure.
+    IoError,
+    /// Transient failure; a retry may succeed.
+    TempFailure,
+    /// Unclassified: an anyhow error with no known mapping.
+    Unknown,
+}
+
+impl ErrorCode {
+    pub(crate) fn code(self) -> u8 {
+        match self {
+            Self::Usage => codes::USAGE,
+            Self::DataError => codes::DATA_ERROR,
+            Self::Internal => codes::INTERNAL,
+            Self::IoError => codes::IO_ERR,
+            Self::TempFailure => codes::TEMP_FAIL,
+            Self::Unknown => codes::UNKNOWN,
+        }
+    }
+}
+
+/// The explicit, classifiable failures recall raises. Internal functions keep
+/// returning `anyhow::Result`; these variants are constructed at the few sites
+/// that know the right exit class and recovered by downcast at the boundary.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RecallError {
+    /// User invoked the command wrong (maps to `USAGE`, 64).
+    #[error("{0}")]
+    Usage(String),
+    /// User-supplied data was malformed (maps to `DATA_ERROR`, 65).
+    #[error("{0}")]
+    DataError(String),
+    /// Invariant violation or permanent environment fault, e.g. the MLX backend
+    /// is missing on non-Apple-Silicon hardware (maps to `INTERNAL`, 70).
+    #[error("{0}")]
+    Internal(String),
+    /// Transient failure; retry may succeed (maps to `TEMP_FAILURE`, 75).
+    #[error("{0}")]
+    TempFailure(String),
+}
+
+impl RecallError {
+    pub(crate) fn error_code(&self) -> ErrorCode {
+        match self {
+            Self::Usage(_) => ErrorCode::Usage,
+            Self::DataError(_) => ErrorCode::DataError,
+            Self::Internal(_) => ErrorCode::Internal,
+            Self::TempFailure(_) => ErrorCode::TempFailure,
+        }
+    }
+}
+
+impl CliError for RecallError {
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::from(self.error_code().code())
+    }
+}
+
+/// Classify an error that propagated to the CLI boundary into an exit code.
+///
+/// Resolution order: a typed [`RecallError`] wins; then rurico's
+/// [`SanitizeError`] (a failed vocab lookup is I/O, a bad vocab table is a
+/// programmer bug); then raw I/O and SQLite errors; otherwise `UNKNOWN` (104),
+/// which signals an `anyhow` path that should be promoted to a typed variant.
+pub(crate) fn classify_exit_code(err: &anyhow::Error) -> ExitCode {
+    ExitCode::from(classify(err).code())
+}
+
+fn classify(err: &anyhow::Error) -> ErrorCode {
+    if let Some(e) = err.downcast_ref::<RecallError>() {
+        return e.error_code();
+    }
+    if let Some(e) = err.downcast_ref::<SanitizeError>() {
+        return match e {
+            SanitizeError::VocabLookupFailed(_) => ErrorCode::IoError,
+            SanitizeError::InvalidVocabTable(_) => ErrorCode::Internal,
+            SanitizeError::EmptyInput | SanitizeError::NoSearchableTerms => ErrorCode::DataError,
+        };
+    }
+    if err.downcast_ref::<io::Error>().is_some() || err.downcast_ref::<rusqlite::Error>().is_some()
+    {
+        return ErrorCode::IoError;
+    }
+    ErrorCode::Unknown
+}
+
+/// Classify a `recall model download` failure. A failed HTTP download or a
+/// re-downloadable probe failure is transient (retry may help); a missing MLX
+/// backend is a permanent hardware mismatch, so it must not invite a retry.
+pub(crate) fn download_error(e: &ModelDownloadError) -> RecallError {
+    let msg = e.to_string();
+    match e {
+        ModelDownloadError::DownloadFailed(_) | ModelDownloadError::ProbeFailed(_) => {
+            RecallError::TempFailure(msg)
+        }
+        ModelDownloadError::BackendUnavailable => RecallError::Internal(msg),
+    }
+}
+
+/// Classify why the embedder failed to load for a command that requires it
+/// (`recall embed`). A missing model is a usage error the user resolves with
+/// `recall model download`; a missing backend is a permanent fault; a probe
+/// failure may clear on retry.
+pub(crate) fn embedder_error(reason: DegradedReason) -> RecallError {
+    match reason {
+        DegradedReason::NotInstalled => RecallError::Usage(
+            "embedding model not installed; run `recall model download`".to_owned(),
+        ),
+        DegradedReason::ProbeFailed => {
+            RecallError::TempFailure("embedding model probe failed".to_owned())
+        }
+        DegradedReason::BackendUnavailable => {
+            RecallError::Internal("MLX backend unavailable".to_owned())
+        }
+        DegradedReason::Disabled => RecallError::Internal("embedder disabled".to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_code_numbers_match_sysexits_baseline() {
+        assert_eq!(ErrorCode::Usage.code(), 64);
+        assert_eq!(ErrorCode::DataError.code(), 65);
+        assert_eq!(ErrorCode::Internal.code(), 70);
+        assert_eq!(ErrorCode::IoError.code(), 74);
+        assert_eq!(ErrorCode::TempFailure.code(), 75);
+        assert_eq!(ErrorCode::Unknown.code(), 104);
+    }
+
+    #[test]
+    fn recall_error_classifies_per_variant() {
+        assert_eq!(
+            RecallError::Usage("x".into()).error_code(),
+            ErrorCode::Usage
+        );
+        assert_eq!(
+            RecallError::DataError("x".into()).error_code(),
+            ErrorCode::DataError
+        );
+        assert_eq!(
+            RecallError::Internal("x".into()).error_code(),
+            ErrorCode::Internal
+        );
+        assert_eq!(
+            RecallError::TempFailure("x".into()).error_code(),
+            ErrorCode::TempFailure
+        );
+    }
+
+    #[test]
+    fn classify_recovers_typed_recall_error_through_anyhow() {
+        let err = anyhow::Error::new(RecallError::DataError("bad query".into()));
+        assert_eq!(classify(&err), ErrorCode::DataError);
+    }
+
+    #[test]
+    fn classify_recovers_recall_error_under_context() {
+        // A typed error wrapped in extra anyhow context still classifies.
+        let err =
+            anyhow::Error::new(RecallError::Usage("no query".into())).context("while searching");
+        assert_eq!(classify(&err), ErrorCode::Usage);
+    }
+
+    #[test]
+    fn classify_maps_sanitize_vocab_lookup_to_io() {
+        let err = anyhow::Error::new(SanitizeError::VocabLookupFailed("disk".into()));
+        assert_eq!(classify(&err), ErrorCode::IoError);
+    }
+
+    #[test]
+    fn classify_maps_raw_io_error() {
+        let err = anyhow::Error::new(io::Error::other("boom"));
+        assert_eq!(classify(&err), ErrorCode::IoError);
+    }
+
+    #[test]
+    fn classify_falls_back_to_unknown_for_unmapped_anyhow() {
+        let err = anyhow::anyhow!("something unclassified");
+        assert_eq!(classify(&err), ErrorCode::Unknown);
+    }
+
+    // A permanent backend mismatch must not be retryable; only network/probe
+    // failures are transient.
+    #[test]
+    fn download_error_classifies_backend_as_permanent() {
+        assert_eq!(
+            download_error(&ModelDownloadError::BackendUnavailable).error_code(),
+            ErrorCode::Internal
+        );
+        assert_eq!(
+            download_error(&ModelDownloadError::DownloadFailed("net".into())).error_code(),
+            ErrorCode::TempFailure
+        );
+        assert_eq!(
+            download_error(&ModelDownloadError::ProbeFailed("corrupt".into())).error_code(),
+            ErrorCode::TempFailure
+        );
+    }
+
+    // `recall embed` without the model installed is a usage error the user
+    // fixes with `recall model download`, not an Unknown(104) catch-all.
+    #[test]
+    fn embedder_error_classifies_not_installed_as_usage() {
+        assert_eq!(
+            embedder_error(DegradedReason::NotInstalled).error_code(),
+            ErrorCode::Usage
+        );
+        assert_eq!(
+            embedder_error(DegradedReason::BackendUnavailable).error_code(),
+            ErrorCode::Internal
+        );
+        assert_eq!(
+            embedder_error(DegradedReason::ProbeFailed).error_code(),
+            ErrorCode::TempFailure
+        );
+        assert_eq!(
+            embedder_error(DegradedReason::Disabled).error_code(),
+            ErrorCode::Internal
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -201,6 +201,38 @@ mod tests {
     }
 
     #[test]
+    fn classify_maps_invalid_vocab_table_to_internal() {
+        let err = anyhow::Error::new(SanitizeError::InvalidVocabTable("1bad".into()));
+        assert_eq!(classify(&err), ErrorCode::Internal);
+    }
+
+    #[test]
+    fn classify_maps_empty_query_to_data_error() {
+        assert_eq!(
+            classify(&anyhow::Error::new(SanitizeError::EmptyInput)),
+            ErrorCode::DataError
+        );
+        assert_eq!(
+            classify(&anyhow::Error::new(SanitizeError::NoSearchableTerms)),
+            ErrorCode::DataError
+        );
+    }
+
+    // The public ExitCode wrappers (classify_exit_code, CliError::exit_code)
+    // must agree with the ErrorCode::code() table they delegate to.
+    #[test]
+    fn exit_code_wrappers_agree_with_code_table() {
+        assert_eq!(
+            classify_exit_code(&anyhow::Error::new(RecallError::Usage("x".into()))),
+            ExitCode::from(codes::USAGE)
+        );
+        assert_eq!(
+            RecallError::DataError("x".into()).exit_code(),
+            ExitCode::from(codes::DATA_ERROR)
+        );
+    }
+
+    #[test]
     fn classify_maps_raw_io_error() {
         let err = anyhow::Error::new(io::Error::other("boom"));
         assert_eq!(classify(&err), ErrorCode::IoError);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod chunker;
 mod date;
 mod db;
 mod embedder;
+mod error;
 mod hybrid;
 mod indexer;
 mod parser;
@@ -13,9 +14,10 @@ use std::ffi::OsString;
 use std::fs::OpenOptions;
 use std::io::{self, ErrorKind, Write};
 use std::path::{Path, PathBuf};
-use std::process;
+use std::process::{self, ExitCode};
 use std::sync::Arc;
 
+use amici::cli::exit_code::codes;
 use amici::cli::{
     Spinner, done, embed_with_spinners, exit_error, info as cli_info, progress_step,
     try_expand_shorthand,
@@ -25,16 +27,15 @@ use amici::model::download_and_verify_model;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
 use amici::storage::filter::escape_like;
 use anyhow::{Context, Result};
+use clap::error::ErrorKind as ClapErrorKind;
 use clap::{Parser, Subcommand};
 use rurico::embed::{Embed, ModelId, cached_artifacts};
 use rurico::handle_probe_if_needed;
 use rusqlite::Connection;
 use tracing::{info, warn};
 
+use crate::error::{RecallError, classify_exit_code, download_error, embedder_error};
 use crate::parser::Source;
-
-/// Keep in sync with bail! sites: `run()` and `find_candidate_sessions()`.
-const USER_ERROR_MARKERS: &[&str] = &["search query is required", "Invalid search query"];
 
 const LOG_FILTER_VERBOSE: &str = "recall=info";
 const LOG_FILTER_DEFAULT: &str = "recall=warn";
@@ -275,21 +276,11 @@ fn run_embed(db_path: &Option<PathBuf>) -> Result<()> {
 }
 
 fn load_cached_embedder() -> Result<Arc<dyn Embed>> {
-    open_cached_embedder().map_err(|reason| {
-        let hint = match reason {
-            DegradedReason::NotInstalled => {
-                "embedding model not installed; run `recall model download`"
-            }
-            DegradedReason::BackendUnavailable => "MLX backend unavailable",
-            DegradedReason::ProbeFailed => "embedding model probe failed",
-            DegradedReason::Disabled => "embedder disabled",
-        };
-        anyhow::anyhow!("{hint}")
-    })
+    open_cached_embedder().map_err(|reason| embedder_error(reason).into())
 }
 
 fn run_model_download() -> Result<()> {
-    download_and_verify_model().map_err(|e| anyhow::anyhow!("{e}"))
+    download_and_verify_model().map_err(|e| download_error(&e).into())
 }
 
 /// Guidance when search runs against an empty index. `recall search` no longer
@@ -400,7 +391,7 @@ fn show_session(
         .collect::<Result<_, _>>()?;
 
     if matches.is_empty() {
-        anyhow::bail!("No session found matching '{session_id}'");
+        return Err(RecallError::Usage(format!("No session found matching '{session_id}'")).into());
     }
     if matches.len() > 1 {
         let mut msg = format!("Multiple sessions match '{session_id}':\n");
@@ -408,7 +399,7 @@ fn show_session(
             msg.push_str(&format!("  {}  {}\n", s.session_id, s.slug));
         }
         msg.push_str("Narrow the session ID prefix to match exactly one session");
-        anyhow::bail!(msg);
+        return Err(RecallError::Usage(msg).into());
     }
 
     let session = &matches[0];
@@ -440,7 +431,9 @@ fn show_session(
 fn run_show(session_id: &str, verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
     let path = resolve_db_path(db_path)?;
     if !path.exists() {
-        anyhow::bail!("Database not found. Run `recall index` first.");
+        return Err(
+            RecallError::Usage("Database not found. Run `recall index` first.".to_owned()).into(),
+        );
     }
 
     let conn = open_or_create_db(&path)?;
@@ -582,13 +575,31 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
 ];
 const GLOBAL_FLAGS: &[&str] = &["--verbose", "-v"];
 
-fn run() -> Result<()> {
-    let args: Vec<OsString> = env::args_os().collect();
-    let cli = match try_expand_shorthand(&args, KNOWN_SUBCOMMANDS, GLOBAL_FLAGS) {
-        Some(expanded) => Cli::parse_from(expanded),
-        None => Cli::parse_from(args),
+/// Parse argv into a [`Cli`], expanding shorthand first. Both expansion
+/// branches funnel through one `try_parse_from`, so a parse error prints once.
+/// Returns the exit code to use when parsing does not yield a command:
+/// success for `--help`, `USAGE` (64) for a real parse error.
+fn parse_cli(args: Vec<OsString>) -> Result<Cli, ExitCode> {
+    let parsed = match try_expand_shorthand(&args, KNOWN_SUBCOMMANDS, GLOBAL_FLAGS) {
+        Some(expanded) => Cli::try_parse_from(expanded),
+        None => Cli::try_parse_from(args),
     };
+    parsed.map_err(|e| handle_parse_error(&e))
+}
 
+/// Print a clap parse error (or `--help` text) and map it to an exit code.
+/// `--help` is not a failure (clap writes it to stdout); everything else is a
+/// usage error. recall defines no `--version`, so it falls through to `USAGE`
+/// like any other unknown flag.
+fn handle_parse_error(err: &clap::Error) -> ExitCode {
+    let _ = err.print();
+    match err.kind() {
+        ClapErrorKind::DisplayHelp => ExitCode::SUCCESS,
+        _ => ExitCode::from(codes::USAGE),
+    }
+}
+
+fn run(cli: Cli) -> Result<()> {
     let default_filter = if cli.verbose {
         LOG_FILTER_VERBOSE
     } else {
@@ -604,27 +615,27 @@ fn run() -> Result<()> {
         Some(cmd @ Command::Search { .. }) => run_search(cmd, &cli.db_path),
         Some(Command::Show { session_id }) => run_show(&session_id, cli.verbose, &cli.db_path),
         Some(Command::Status) => run_status(cli.verbose, &cli.db_path),
-        None => {
-            anyhow::bail!(
-                "A search query is required. Usage: recall search \"query\" or recall index"
-            )
-        }
+        None => Err(RecallError::Usage(
+            "A search query is required. Usage: recall search \"query\" or recall index".to_owned(),
+        )
+        .into()),
     }
 }
 
-/// Exit codes: 1 = user error (bad query, missing args), 2 = system error (IO, DB).
-fn main() {
+fn main() -> ExitCode {
     handle_probe_if_needed();
 
-    if let Err(e) = run() {
-        let msg = format!("{e:#}");
-        exit_error(&msg);
-        let code = if USER_ERROR_MARKERS.iter().any(|m| msg.contains(m)) {
-            1
-        } else {
-            2
-        };
-        process::exit(code);
+    let cli = match parse_cli(env::args_os().collect()) {
+        Ok(cli) => cli,
+        Err(code) => return code,
+    };
+
+    match run(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            exit_error(&format!("{e:#}"));
+            classify_exit_code(&e)
+        }
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -14,6 +14,7 @@ use rusqlite::types::ToSql;
 use tracing::{debug, warn};
 
 use crate::embedder::f32_as_bytes;
+use crate::error::RecallError;
 use crate::hybrid::rrf_merge_strings;
 
 use crate::date::MS_PER_DAY;
@@ -132,9 +133,10 @@ fn find_candidate_sessions(
     }
     if let Some(ref err_msg) = first_error {
         if ranked.is_empty() {
-            anyhow::bail!(
+            return Err(RecallError::DataError(format!(
                 "Invalid search query: {err_msg}. Use words, \"quoted phrases\", or AND/OR/NOT operators."
-            );
+            ))
+            .into());
         }
         warn!(skipped, %err_msg, "rows skipped during search");
     }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,0 +1,89 @@
+//! CLI exit-code contract (ADR-0066 Group 2, #82). Spawns the real binary and
+//! pins the sysexits codes agents branch on, exercising the parse / dispatch /
+//! error-classification glue that unit tests cannot reach in-process.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// A `recall` invocation isolated from the developer's real sessions and DB.
+/// `RECALL_DB` points at a path inside `dir`; the source dirs point nowhere so
+/// indexing never touches `~/.claude` or `~/.codex`.
+fn recall(dir: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_recall"));
+    cmd.env("RECALL_DB", dir.join("recall.db"))
+        .env("RECALL_CLAUDE_DIR", dir.join("no-claude"))
+        .env("RECALL_CODEX_DIR", dir.join("no-codex"));
+    cmd
+}
+
+fn exit_code(cmd: &mut Command) -> i32 {
+    cmd.output()
+        .expect("spawn recall binary")
+        .status
+        .code()
+        .expect("process returned an exit code")
+}
+
+// T-CLI001: an unknown flag is a usage error (clap parse → USAGE 64).
+#[test]
+fn unknown_flag_exits_usage() {
+    let dir = TempDir::new().unwrap();
+    assert_eq!(exit_code(recall(dir.path()).arg("--no-such-flag")), 64);
+}
+
+// T-CLI002: no subcommand prints the "search query required" usage error (64).
+#[test]
+fn no_subcommand_exits_usage() {
+    let dir = TempDir::new().unwrap();
+    assert_eq!(exit_code(&mut recall(dir.path())), 64);
+}
+
+// T-CLI003: --help is not a failure; clap writes help to stdout and exits 0.
+#[test]
+fn help_exits_success() {
+    let dir = TempDir::new().unwrap();
+    assert_eq!(exit_code(recall(dir.path()).arg("--help")), 0);
+}
+
+// T-CLI004: `show` against a database that was never created is a usage error
+// (run `recall index` first), not a crash.
+#[test]
+fn show_without_database_exits_usage() {
+    let dir = TempDir::new().unwrap();
+    assert_eq!(exit_code(recall(dir.path()).args(["show", "deadbeef"])), 64);
+}
+
+// T-CLI005: searching an empty (but created) index is a success that prints the
+// "no sessions indexed" guidance, exit 0 — not an error.
+#[test]
+fn search_empty_index_exits_success() {
+    let dir = TempDir::new().unwrap();
+    assert_eq!(
+        exit_code(recall(dir.path()).args(["search", "anything", "--no-embed"])),
+        0
+    );
+}
+
+// T-CLI007: a bare query with no subcommand is shorthand-expanded to `search`,
+// exercising the shorthand-expansion parse branch. Empty index → success (0).
+#[test]
+fn bare_query_shorthand_expands_to_search() {
+    let dir = TempDir::new().unwrap();
+    assert_eq!(
+        exit_code(recall(dir.path()).args(["someword", "--no-embed"])),
+        0
+    );
+}
+
+// T-CLI006: `show` of an unknown id against an existing index resolves to no
+// match → usage error (64). Creating the index first (via search) makes the DB
+// exist, so this exercises the "No session found" path, not "Database not found".
+#[test]
+fn show_unknown_id_in_existing_index_exits_usage() {
+    let dir = TempDir::new().unwrap();
+    // `index` creates the (empty) database without needing the embedding model.
+    assert_eq!(exit_code(recall(dir.path()).arg("index")), 0);
+    assert_eq!(exit_code(recall(dir.path()).args(["show", "deadbeef"])), 64);
+}


### PR DESCRIPTION
## 概要

ADR-0066 Group 2 に沿って exit code を分類する。`USER_ERROR_MARKERS` の stderr 文字列マッチ(exit 1/2 の二値)を撤廃し、型付きエラーから sysexits 数値コードへマップする。AI エージェント・スクリプトがエラー文字列を parse せず数値で分岐できるようになる(#82/#83/#26)。

## 変更内容

- **`src/error.rs`(新規)**: `ErrorCode`(Usage 64 / DataError 65 / Internal 70 / IoError 74 / TempFailure 75 / Unknown 104)+ `RecallError`(thiserror)+ amici `CliError` 実装。`classify_exit_code` が anyhow チェーンを downcast(RecallError → SanitizeError → io/rusqlite → Unknown)。
- **`main()` → `ExitCode` 返却**: CLI parse を `parse_cli` に集約し、clap parse error → USAGE(64)、`--help` → 0。両 shorthand 経路を 1 つの `try_parse_from` に funnel し parse error の二重 print を回避。
- **bail サイトの型付け**: クエリ未指定 / セッション未解決 / 曖昧な prefix / index 未作成 → Usage、クエリ形式不正 → DataError。
- **model download / embed の失敗分類**: MLX backend 欠如は恒久(Internal)、モデル未インストールは usage error(`recall model download` を促す)、ネットワーク/probe 失敗は transient(TempFailure)。これにより agent が恒久エラーで retry-loop に陥らない。

## 破壊的変更

exit code が変わる。従来は不正/未指定クエリで 1、その他すべて 2 だったが、今後は sysexits コード(64/65/70/74/75)または分類不能で 104 を返す。exit 1/2 に依存するスクリプトは更新が必要。

## 設計判断

Option B(anyhow 維持 + 境界で downcast 分類)を採用。全関数を typed error に変換する案は、exit-code と無関係な indexer/chunker/db まで波及し scope 不良なため見送り(recall は `.context()` 不使用で typed 化の利得も薄い)。詳細は #82 コメント参照。

`--json error.code`(#82 AC 項目4)は `--json` envelope(#67 G1、未実装)依存のため defer。本 PR は exit-code 軸のみ。

## /polish 実施

code-review(5源)+ Codex + CodeRabbit + critic-audit。実バグ 2 件を捕捉・修正:
- BackendUnavailable を TempFailure(retry可)に誤分類 → 非 Apple Silicon で agent が無限 retry。Internal(恒久)に修正。
- `recall embed` 未インストールが Unknown(104) に落ちていた(撤廃したはずの文字列 anti-pattern 再発)→ Usage(64) に typed 化。

## 検証

- `cargo test`: 126 passed(error.rs に分類テスト追加、call-site 回帰テスト含む)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: OK
- exit code 実測: bad flag / not found / no subcommand / --version → 64、--help / 検索 / shorthand → 0

Closes #82
Closes #83
Closes #26
