### PR TITLE
feat(cli): 全コマンドに --json エンベロープを追加 (#67 Phase 2)

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -58,7 +58,7 @@ impl CommandOutput {
 }
 
 /// Serialized to stdout when `--json` is set.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct SuccessEnvelope {
     pub data: serde_json::Value,
     pub degraded: bool,
@@ -67,7 +67,7 @@ pub(crate) struct SuccessEnvelope {
 
 /// Serialized to stderr when `--json` is set and the command failed. Wrapping the
 /// payload under `error` lets consumers branch on the root key.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct ErrorEnvelope {
     pub error: ErrorPayload,
 }
@@ -76,7 +76,7 @@ pub(crate) struct ErrorEnvelope {
 ///
 /// `next_step` and `candidates` are omitted from JSON when absent/empty, keeping
 /// the envelope compact when no structured guidance applies.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct ErrorPayload {
     pub code: ErrorCode,
     pub message: String,

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,0 +1,373 @@
+//! Output envelopes for `--json` mode (ADR-0060, #67 Phase 2).
+//!
+//! Mirrors `sae/src/envelope.rs`. [`CommandOutput`] is the canonical runner
+//! return type, pairing the human-facing `markdown` with the machine `data`
+//! plus `degraded`/`notes` signals. [`SuccessEnvelope`] and [`ErrorEnvelope`]
+//! are the wire shapes serialized to stdout/stderr under `--json`.
+//!
+//! recall has no `CantCreat` (73) class — DB/IO failures map to `IoError` (see
+//! [`crate::error::ErrorCode`]).
+
+use serde::Serialize;
+
+use crate::error::ErrorCode;
+
+/// Canonical return type for command runners (#67 Phase 2).
+///
+/// `markdown` is the human-facing rendering surfaced when `--json` is absent.
+/// `data` is the machine payload mirrored into [`SuccessEnvelope::data`] when
+/// `--json` is set; runners build it with `serde_json::json!` so the public JSON
+/// schema stays decoupled from internal types ([`crate::search::SearchResult`] /
+/// [`crate::parser::SessionData`] deliberately stay non-`Serialize`). `degraded`
+/// and `notes` surface deviations from the ideal path so agents can react —
+/// currently set only by `search`, when the embedding model is not installed and
+/// ranking falls back to FTS-only.
+#[derive(Debug)]
+pub(crate) struct CommandOutput {
+    pub markdown: String,
+    pub data: serde_json::Value,
+    pub degraded: bool,
+    pub notes: Vec<String>,
+}
+
+impl CommandOutput {
+    /// An ideal-path result: not degraded, no notes.
+    pub(crate) fn ok(markdown: String, data: serde_json::Value) -> Self {
+        Self {
+            markdown,
+            data,
+            degraded: false,
+            notes: Vec::new(),
+        }
+    }
+
+    /// A result that may have taken a fallback path; `degraded` + `notes` record it.
+    pub(crate) fn with_notes(
+        markdown: String,
+        data: serde_json::Value,
+        degraded: bool,
+        notes: Vec<String>,
+    ) -> Self {
+        Self {
+            markdown,
+            data,
+            degraded,
+            notes,
+        }
+    }
+}
+
+/// Serialized to stdout when `--json` is set.
+#[derive(Serialize)]
+pub(crate) struct SuccessEnvelope {
+    pub data: serde_json::Value,
+    pub degraded: bool,
+    pub notes: Vec<String>,
+}
+
+/// Serialized to stderr when `--json` is set and the command failed. Wrapping the
+/// payload under `error` lets consumers branch on the root key.
+#[derive(Serialize)]
+pub(crate) struct ErrorEnvelope {
+    pub error: ErrorPayload,
+}
+
+/// Error payload nested under [`ErrorEnvelope::error`].
+///
+/// `next_step` and `candidates` are omitted from JSON when absent/empty, keeping
+/// the envelope compact when no structured guidance applies.
+#[derive(Serialize)]
+pub(crate) struct ErrorPayload {
+    pub code: ErrorCode,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_step: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<String>,
+    pub retryable: bool,
+}
+
+/// Serializes a successful result to the wire envelope.
+pub(crate) fn render_json_success(out: &CommandOutput) -> String {
+    let env = SuccessEnvelope {
+        data: out.data.clone(),
+        degraded: out.degraded,
+        notes: out.notes.clone(),
+    };
+    serde_json::to_string(&env).expect("SuccessEnvelope is always serializable")
+}
+
+/// Serializes a prepared error envelope to the wire format. The [`ErrorEnvelope`]
+/// is assembled by the caller (via [`crate::error::RecallError::to_error_envelope`]),
+/// keeping this module a pure serializer that never constructs a `RecallError`.
+pub(crate) fn render_json_error(env: &ErrorEnvelope) -> String {
+    serde_json::to_string(env).expect("ErrorEnvelope is always serializable")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CommandOutput, ErrorEnvelope, ErrorPayload, SuccessEnvelope};
+    use super::{render_json_error, render_json_success};
+    use crate::error::ErrorCode;
+
+    // T-EN001: error_payload_omits_optional_next_step_when_none
+    // Perspective: boundary (None is the empty/min case for the optional field).
+    // next_step=None must not emit the key, keeping the envelope compact.
+    #[test]
+    fn error_payload_omits_optional_next_step_when_none() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: "A search query is required.".into(),
+            next_step: None,
+            candidates: vec![],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !json.contains("next_step"),
+            "next_step should be omitted when None, got: {json}"
+        );
+    }
+
+    // T-EN002: error_payload_omits_candidates_when_empty
+    // Perspective: boundary (empty Vec is the min case). An empty candidates list
+    // must not emit the key.
+    #[test]
+    fn error_payload_omits_candidates_when_empty() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: "No session found matching 'dead'.".into(),
+            next_step: None,
+            candidates: vec![],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !json.contains("candidates"),
+            "candidates should be omitted when empty, got: {json}"
+        );
+    }
+
+    // T-EN003: error_payload_serializes_present_optional_fields
+    // Perspective: equivalence (the "guidance present" class — both optional
+    // fields populated). next_step=Some and a non-empty candidates list both
+    // appear with their values.
+    #[test]
+    fn error_payload_serializes_present_optional_fields() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: "Multiple sessions match 'de'.".into(),
+            next_step: Some("Narrow the session ID prefix.".into()),
+            candidates: vec!["deadbeef".into(), "decade01".into()],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            json.contains(r#""next_step":"Narrow the session ID prefix.""#),
+            "next_step value should appear, got: {json}"
+        );
+        assert!(
+            json.contains(r#""candidates":["deadbeef","decade01"]"#),
+            "candidates values should appear, got: {json}"
+        );
+    }
+
+    // T-EN004: error_payload_renders_code_in_context
+    // Perspective: equivalence (the code field renders the enum to its
+    // SCREAMING_SNAKE_CASE string when nested in a payload). The exhaustive
+    // variant table lives in error.rs (T-ERR002); this pins the in-context
+    // rendering this module owns, plus the retryable=true class.
+    #[test]
+    fn error_payload_renders_code_in_context() {
+        let payload = ErrorPayload {
+            code: ErrorCode::TempFailure,
+            message: "embedding model probe failed".into(),
+            next_step: Some("Retry; the probe may succeed.".into()),
+            candidates: vec![],
+            retryable: true,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            json.contains(r#""code":"TEMP_FAILURE""#),
+            "code should render in SCREAMING_SNAKE_CASE, got: {json}"
+        );
+        assert!(
+            json.contains(r#""retryable":true"#),
+            "retryable should render as a bool, got: {json}"
+        );
+    }
+
+    // T-EN005: error_envelope_wraps_payload_under_error_key
+    // Perspective: equivalence (the wrap shape). The envelope is a single object
+    // whose only key is `error`, and the nested payload carries the code.
+    #[test]
+    fn error_envelope_wraps_payload_under_error_key() {
+        let env = ErrorEnvelope {
+            error: ErrorPayload {
+                code: ErrorCode::UsageError,
+                message: "A search query is required.".into(),
+                next_step: None,
+                candidates: vec![],
+                retryable: false,
+            },
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            json.starts_with(r#"{"error":"#),
+            "envelope must start with `{{\"error\":`, got: {json}"
+        );
+        assert!(
+            json.contains(r#""code":"USAGE_ERROR""#),
+            "payload must contain the code, got: {json}"
+        );
+    }
+
+    // T-EN006: success_envelope_serializes_required_fields
+    // Perspective: equivalence (the ideal-path shape — not degraded, no notes).
+    // data, degraded, and notes are always present, even when notes is empty.
+    #[test]
+    fn success_envelope_serializes_required_fields() {
+        let env = SuccessEnvelope {
+            data: serde_json::json!({"results": []}),
+            degraded: false,
+            notes: vec![],
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            json.contains(r#""data":{"results":[]}"#),
+            "data should appear, got: {json}"
+        );
+        assert!(
+            json.contains(r#""degraded":false"#),
+            "degraded should appear, got: {json}"
+        );
+        assert!(
+            json.contains(r#""notes":[]"#),
+            "notes should appear, got: {json}"
+        );
+    }
+
+    // T-EN007: success_envelope_surfaces_degradation_with_notes
+    // Perspective: equivalence (the degraded class — semantic search unavailable,
+    // FTS fallback taken). degraded=true plus a populated note both surface.
+    #[test]
+    fn success_envelope_surfaces_degradation_with_notes() {
+        let env = SuccessEnvelope {
+            data: serde_json::json!({"results": []}),
+            degraded: true,
+            notes: vec!["semantic search unavailable, falling back to FTS".into()],
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            json.contains(r#""degraded":true"#),
+            "degraded should surface, got: {json}"
+        );
+        assert!(
+            json.contains(r#""notes":["semantic search unavailable, falling back to FTS"]"#),
+            "the degradation note should surface, got: {json}"
+        );
+    }
+
+    // T-EN008: render_json_success_serializes_command_output
+    // Perspective: equivalence (the renderer maps a non-degraded CommandOutput to
+    // the success wire shape). The data payload, degraded=false, and empty notes
+    // all round-trip through the renderer.
+    #[test]
+    fn render_json_success_serializes_command_output() {
+        let out = CommandOutput::ok(
+            "Sessions: 5".into(),
+            serde_json::json!({"sessions": 5, "qa_chunks": 12, "embedded": 0}),
+        );
+        let json = render_json_success(&out);
+        assert!(
+            json.contains(r#""sessions":5"#),
+            "data should carry the runner-built keys, got: {json}"
+        );
+        assert!(
+            json.contains(r#""degraded":false"#),
+            "degraded should be false for ok(), got: {json}"
+        );
+        assert!(
+            json.contains(r#""notes":[]"#),
+            "notes should be empty, got: {json}"
+        );
+    }
+
+    // T-EN009: render_json_success_surfaces_notes
+    // Perspective: equivalence (the renderer carries degradation through). A
+    // with_notes CommandOutput surfaces degraded=true and the note text.
+    #[test]
+    fn render_json_success_surfaces_notes() {
+        let out = CommandOutput::with_notes(
+            "No matching sessions found.".into(),
+            serde_json::json!({"results": []}),
+            true,
+            vec!["semantic search unavailable, falling back to FTS".into()],
+        );
+        let json = render_json_success(&out);
+        assert!(
+            json.contains(r#""degraded":true"#),
+            "degraded should surface, got: {json}"
+        );
+        assert!(
+            json.contains(r#""semantic search unavailable, falling back to FTS""#),
+            "the note text should surface, got: {json}"
+        );
+    }
+
+    // T-EN010: render_json_error_wraps_payload
+    // Perspective: equivalence (the error renderer maps a prepared envelope to the
+    // wire shape). The `{"error":...}` wrap, the code string, and retryable=true
+    // all survive serialization.
+    #[test]
+    fn render_json_error_wraps_payload() {
+        let env = ErrorEnvelope {
+            error: ErrorPayload {
+                code: ErrorCode::TempFailure,
+                message: "embedding model probe failed".into(),
+                next_step: Some("Retry; the probe may succeed.".into()),
+                candidates: vec![],
+                retryable: true,
+            },
+        };
+        let json = render_json_error(&env);
+        assert!(
+            json.starts_with(r#"{"error":"#),
+            "the error envelope must start with `{{\"error\":`, got: {json}"
+        );
+        assert!(
+            json.contains(r#""code":"TEMP_FAILURE""#),
+            "the code should appear, got: {json}"
+        );
+        assert!(
+            json.contains(r#""retryable":true"#),
+            "retryable should appear, got: {json}"
+        );
+    }
+
+    // T-EN011: render_json_error_marks_non_retryable
+    // Perspective: condition (the false side of retryable). A usage error renders
+    // retryable=false — the complement of T-EN010's true case, so the field is
+    // proven to vary, not hard-coded.
+    #[test]
+    fn render_json_error_marks_non_retryable() {
+        let env = ErrorEnvelope {
+            error: ErrorPayload {
+                code: ErrorCode::UsageError,
+                message: "A search query is required.".into(),
+                next_step: Some("Run `recall search \"query\"`.".into()),
+                candidates: vec![],
+                retryable: false,
+            },
+        };
+        let json = render_json_error(&env);
+        assert!(
+            json.contains(r#""code":"USAGE_ERROR""#),
+            "the code should appear, got: {json}"
+        );
+        assert!(
+            json.contains(r#""retryable":false"#),
+            "a usage error must render retryable=false, got: {json}"
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,12 +18,20 @@ use amici::cli::exit_code::{CliError, codes};
 use amici::model::ModelDownloadError;
 use amici::model::embedder::DegradedReason;
 use rurico::storage::SanitizeError;
+use serde::Serialize;
+
+use crate::envelope::{ErrorEnvelope, ErrorPayload};
 
 /// sysexits-derived exit-code classes recall distinguishes (ADR-0066 Group 2).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serializes to its SCREAMING_SNAKE_CASE name for the `--json` error envelope
+/// (#67 Phase 2), so agents branch on the concept name (`"USAGE_ERROR"`), not
+/// the bare sysexits number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum ErrorCode {
     /// Command used wrong: missing query, unresolved or ambiguous id, no index.
-    Usage,
+    UsageError,
     /// Malformed input data: an unparseable search query.
     DataError,
     /// Invariant violation or programmer error.
@@ -39,7 +47,7 @@ pub(crate) enum ErrorCode {
 impl ErrorCode {
     pub(crate) fn code(self) -> u8 {
         match self {
-            Self::Usage => codes::USAGE,
+            Self::UsageError => codes::USAGE,
             Self::DataError => codes::DATA_ERROR,
             Self::Internal => codes::INTERNAL,
             Self::IoError => codes::IO_ERR,
@@ -72,10 +80,43 @@ pub(crate) enum RecallError {
 impl RecallError {
     pub(crate) fn error_code(&self) -> ErrorCode {
         match self {
-            Self::Usage(_) => ErrorCode::Usage,
+            Self::Usage(_) => ErrorCode::UsageError,
             Self::DataError(_) => ErrorCode::DataError,
             Self::Internal(_) => ErrorCode::Internal,
             Self::TempFailure(_) => ErrorCode::TempFailure,
+        }
+    }
+
+    /// Build the `--json` error envelope for this failure (#67 Phase 2).
+    ///
+    /// `retryable` is true only for [`Self::TempFailure`]: retrying the same
+    /// call cannot clear a usage, data, or internal fault. `next_step` carries
+    /// variant-level guidance (the specific cause stays in `message`), derived
+    /// from the variant rather than the message text so a reworded `bail!` never
+    /// silently drops the hint (the #82 lesson that retired `USER_ERROR_MARKERS`).
+    pub(crate) fn to_error_envelope(&self) -> ErrorEnvelope {
+        let next_step = match self {
+            Self::Usage(_) => Some(
+                "See `recall --help`; if the index is missing, run `recall index` first."
+                    .to_owned(),
+            ),
+            Self::DataError(_) => Some(
+                "Revise the query: drop bare AND/OR/NOT operators and recheck the syntax."
+                    .to_owned(),
+            ),
+            Self::TempFailure(_) => {
+                Some("Retry the command; the failure may be transient.".to_owned())
+            }
+            Self::Internal(_) => None,
+        };
+        ErrorEnvelope {
+            error: ErrorPayload {
+                code: self.error_code(),
+                message: self.to_string(),
+                next_step,
+                candidates: Vec::new(),
+                retryable: matches!(self, Self::TempFailure(_)),
+            },
         }
     }
 }
@@ -94,6 +135,28 @@ impl CliError for RecallError {
 /// which signals an `anyhow` path that should be promoted to a typed variant.
 pub(crate) fn classify_exit_code(err: &anyhow::Error) -> ExitCode {
     ExitCode::from(classify(err).code())
+}
+
+/// Build the `--json` error envelope for any error reaching the CLI boundary
+/// (#67 Phase 2). A typed [`RecallError`] carries its own `next_step` /
+/// `retryable` via [`RecallError::to_error_envelope`]; an untyped `anyhow` error
+/// is classified by [`classify`] and rendered without structured guidance
+/// (`next_step: None`), mirroring the exit-code path so the JSON and the exit
+/// code never disagree.
+pub(crate) fn error_envelope(err: &anyhow::Error) -> ErrorEnvelope {
+    if let Some(e) = err.downcast_ref::<RecallError>() {
+        return e.to_error_envelope();
+    }
+    let code = classify(err);
+    ErrorEnvelope {
+        error: ErrorPayload {
+            code,
+            message: format!("{err:#}"),
+            next_step: None,
+            candidates: Vec::new(),
+            retryable: matches!(code, ErrorCode::TempFailure),
+        },
+    }
 }
 
 fn classify(err: &anyhow::Error) -> ErrorCode {
@@ -152,7 +215,7 @@ mod tests {
 
     #[test]
     fn error_code_numbers_match_sysexits_baseline() {
-        assert_eq!(ErrorCode::Usage.code(), 64);
+        assert_eq!(ErrorCode::UsageError.code(), 64);
         assert_eq!(ErrorCode::DataError.code(), 65);
         assert_eq!(ErrorCode::Internal.code(), 70);
         assert_eq!(ErrorCode::IoError.code(), 74);
@@ -164,7 +227,7 @@ mod tests {
     fn recall_error_classifies_per_variant() {
         assert_eq!(
             RecallError::Usage("x".into()).error_code(),
-            ErrorCode::Usage
+            ErrorCode::UsageError
         );
         assert_eq!(
             RecallError::DataError("x".into()).error_code(),
@@ -191,7 +254,7 @@ mod tests {
         // A typed error wrapped in extra anyhow context still classifies.
         let err =
             anyhow::Error::new(RecallError::Usage("no query".into())).context("while searching");
-        assert_eq!(classify(&err), ErrorCode::Usage);
+        assert_eq!(classify(&err), ErrorCode::UsageError);
     }
 
     #[test]
@@ -268,7 +331,7 @@ mod tests {
     fn embedder_error_classifies_not_installed_as_usage() {
         assert_eq!(
             embedder_error(DegradedReason::NotInstalled).error_code(),
-            ErrorCode::Usage
+            ErrorCode::UsageError
         );
         assert_eq!(
             embedder_error(DegradedReason::BackendUnavailable).error_code(),
@@ -281,6 +344,111 @@ mod tests {
         assert_eq!(
             embedder_error(DegradedReason::Disabled).error_code(),
             ErrorCode::Internal
+        );
+    }
+
+    // -- #67 Phase 2 (--json envelope) --
+    //
+    // These tests pin the `--json` error surface: the SCREAMING_SNAKE_CASE serde
+    // table for `ErrorCode` and the `to_error_envelope` / `error_envelope`
+    // mapping (code, message, next_step, retryable) per `RecallError` variant.
+
+    // T-ERR002: error_code_serializes_screaming_snake_case
+    // Perspective: equivalence (one representative per variant). The canonical
+    // serde table — owned here because the derive lives on this enum. envelope.rs
+    // only asserts the code rendering in-context, not this exhaustive list.
+    #[test]
+    fn error_code_serializes_screaming_snake_case() {
+        let pairs = [
+            (ErrorCode::UsageError, r#""USAGE_ERROR""#),
+            (ErrorCode::DataError, r#""DATA_ERROR""#),
+            (ErrorCode::Internal, r#""INTERNAL""#),
+            (ErrorCode::IoError, r#""IO_ERROR""#),
+            (ErrorCode::TempFailure, r#""TEMP_FAILURE""#),
+            (ErrorCode::Unknown, r#""UNKNOWN""#),
+        ];
+        for (code, expected) in pairs {
+            let actual = serde_json::to_string(&code).unwrap();
+            assert_eq!(
+                actual, expected,
+                "code {code:?} should serialize as {expected}"
+            );
+        }
+    }
+
+    // T-ERR003: to_error_envelope_marks_usage_non_retryable_with_next_step
+    // Perspective: equivalence (the Usage class). A usage error is not retryable
+    // and carries actionable next_step guidance (the agent fixes the invocation).
+    #[test]
+    fn to_error_envelope_marks_usage_non_retryable_with_next_step() {
+        let env = RecallError::Usage("A search query is required.".into()).to_error_envelope();
+        assert_eq!(env.error.code, ErrorCode::UsageError);
+        assert!(
+            !env.error.retryable,
+            "a usage error must not invite a retry"
+        );
+        assert!(
+            env.error.next_step.is_some(),
+            "a usage error should carry next_step guidance, got: {:?}",
+            env.error.next_step
+        );
+        assert_eq!(env.error.message, "A search query is required.");
+    }
+
+    // T-ERR004: to_error_envelope_marks_temp_failure_retryable
+    // Perspective: equivalence (the transient class). A TempFailure is retryable
+    // and carries next_step guidance. This is the retryable=true complement of
+    // the Usage / Internal / DataError cases. Asserts the behavior (retryable +
+    // guidance present), not the literal wording — matching T-ERR003, so Phase 3
+    // stays free to phrase the retry hint however it likes.
+    #[test]
+    fn to_error_envelope_marks_temp_failure_retryable() {
+        let env =
+            RecallError::TempFailure("embedding model probe failed".into()).to_error_envelope();
+        assert_eq!(env.error.code, ErrorCode::TempFailure);
+        assert!(env.error.retryable, "a transient failure must be retryable");
+        assert!(
+            env.error.next_step.is_some(),
+            "a transient failure should carry next_step guidance, got: {:?}",
+            env.error.next_step
+        );
+    }
+
+    // T-ERR005: to_error_envelope_marks_internal_and_data_non_retryable
+    // Perspective: condition (the false side of retryable for the permanent
+    // classes). Internal (programmer/environment fault) and DataError (malformed
+    // input) are both terminal — a retry of the same call cannot succeed.
+    #[test]
+    fn to_error_envelope_marks_internal_and_data_non_retryable() {
+        let internal = RecallError::Internal("MLX backend unavailable".into()).to_error_envelope();
+        assert_eq!(internal.error.code, ErrorCode::Internal);
+        assert!(
+            !internal.error.retryable,
+            "an internal fault must not be retryable"
+        );
+
+        let data = RecallError::DataError("unparseable query".into()).to_error_envelope();
+        assert_eq!(data.error.code, ErrorCode::DataError);
+        assert!(
+            !data.error.retryable,
+            "a malformed-input error must not be retryable"
+        );
+    }
+
+    // T-ERR006: error_envelope falls back to classify() for an untyped anyhow
+    // error (no RecallError downcast), rendering UNKNOWN without guidance — the
+    // JSON twin of classify_falls_back_to_unknown_for_unmapped_anyhow.
+    #[test]
+    fn error_envelope_classifies_untyped_anyhow() {
+        let env = error_envelope(&anyhow::anyhow!("something unclassified"));
+        assert_eq!(env.error.code, ErrorCode::Unknown);
+        assert!(
+            !env.error.retryable,
+            "an unclassified error must not be retryable"
+        );
+        assert!(
+            env.error.next_step.is_none(),
+            "an untyped error carries no structured next_step"
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -451,4 +451,18 @@ mod tests {
             "an untyped error carries no structured next_step"
         );
     }
+
+    // T-ERR007: error_envelope assembles the IO_ERROR envelope for a raw io::Error
+    // (the untyped path's IoError branch). The JSON twin of classify_maps_raw_io_error,
+    // which pins only the code, not the assembled envelope (code + retryable + next_step).
+    #[test]
+    fn error_envelope_assembles_io_error_for_raw_io() {
+        let env = error_envelope(&anyhow::Error::new(io::Error::other("disk failure")));
+        assert_eq!(env.error.code, ErrorCode::IoError);
+        assert!(!env.error.retryable, "an I/O error must not be retryable");
+        assert!(
+            env.error.next_step.is_none(),
+            "an untyped I/O error carries no structured next_step"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod chunker;
 mod date;
 mod db;
 mod embedder;
+mod envelope;
 mod error;
 mod hybrid;
 mod indexer;
@@ -35,7 +36,10 @@ use rurico::handle_probe_if_needed;
 use rusqlite::Connection;
 use tracing::{info, warn};
 
-use crate::error::{RecallError, classify_exit_code, download_error, embedder_error};
+use crate::envelope::{CommandOutput, render_json_error, render_json_success};
+use crate::error::{
+    RecallError, classify_exit_code, download_error, embedder_error, error_envelope,
+};
 use crate::output::{WriteOutcome, write_result};
 use crate::parser::Source;
 
@@ -55,6 +59,10 @@ struct Cli {
     /// Database file path (default: ~/.recall.db, env: RECALL_DB)
     #[arg(long, env = "RECALL_DB", global = true)]
     db_path: Option<PathBuf>,
+
+    /// Emit a machine-readable JSON envelope instead of human-readable text
+    #[arg(long, global = true)]
+    json: bool,
 }
 
 #[derive(Subcommand)]
@@ -291,7 +299,7 @@ fn search_idle_message(session_count: i64) -> Option<&'static str> {
     (session_count == 0).then_some("No sessions indexed. Run `recall index` first.")
 }
 
-fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<CommandOutput> {
     let Command::Search {
         query,
         project,
@@ -312,10 +320,25 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<()> {
     let session_count: i64 = conn.query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))?;
     if let Some(msg) = search_idle_message(session_count) {
         done(msg);
-        return Ok(());
+        return Ok(CommandOutput::ok(
+            String::new(),
+            serde_json::json!({ "results": [] }),
+        ));
     }
 
     let embedder = try_load_embedder_cached();
+    // A missing embedding model degrades search to FTS-only; surface it so an
+    // agent knows semantic ranking was unavailable (the `--json` notes channel).
+    let (degraded, notes) = match &embedder {
+        Some(_) => (false, Vec::new()),
+        None => (
+            true,
+            vec![
+                "semantic search unavailable: embedding model not installed (run `recall model download`)"
+                    .to_owned(),
+            ],
+        ),
+    };
 
     let results = search::search_with_embedder(
         &conn,
@@ -330,46 +353,54 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<()> {
         embedder.as_deref(),
     )?;
 
-    print_results(&results);
+    let markdown = render_results(&results);
+    let data = serde_json::json!({
+        "results": results.iter().map(result_to_json).collect::<Vec<_>>(),
+    });
 
-    // Post-search: progressive embedding (search results + recent)
+    // Embedding runs after the payload is built, but the result is not emitted
+    // until this returns, so it adds latency; `--no-embed` skips it to keep
+    // piped/scripted usage responsive.
     if !no_embed && let Some(emb) = embedder.as_deref() {
-        let session_ids: Vec<String> = results
-            .iter()
-            .map(|r| r.session.session_id.clone())
-            .collect();
-        let mut total = 0;
-        let mut handle = |result: anyhow::Result<embedder::EmbedResult>| match result {
-            Ok(r) => {
-                r.warn_if_stopped();
-                total += r.embedded;
-            }
-            Err(e) => {
-                warn!(error = %e, "post-search embedding skipped");
-            }
-        };
-        handle(embedder::embed_near_sessions(
-            &mut conn,
-            emb,
-            &session_ids,
-            10,
-            None,
-        ));
-        handle(embedder::embed_recent_chunks(&mut conn, emb, 10, None));
-        if total > 0 {
-            info!(total, "Embedded chunks (nearby + recent)");
-        }
+        embed_around_results(&mut conn, emb, &results);
     }
 
-    Ok(())
+    Ok(CommandOutput::with_notes(markdown, data, degraded, notes))
 }
 
-fn show_session(
-    conn: &Connection,
-    session_id: &str,
-    verbose: bool,
-    w: &mut impl Write,
-) -> Result<()> {
+/// Post-search progressive embedding: a side effect that warms the index around
+/// the hits (nearby sessions) plus the most recent chunks. Progress goes to the
+/// log, not the result. The caller emits its result only after this returns, so
+/// it adds latency; `recall search --no-embed` skips it for interactive use.
+fn embed_around_results(conn: &mut Connection, emb: &dyn Embed, results: &[search::SearchResult]) {
+    let session_ids: Vec<String> = results
+        .iter()
+        .map(|r| r.session.session_id.clone())
+        .collect();
+    let mut total = 0;
+    let mut handle = |result: anyhow::Result<embedder::EmbedResult>| match result {
+        Ok(r) => {
+            r.warn_if_stopped();
+            total += r.embedded;
+        }
+        Err(e) => {
+            warn!(error = %e, "post-search embedding skipped");
+        }
+    };
+    handle(embedder::embed_near_sessions(
+        conn,
+        emb,
+        &session_ids,
+        10,
+        None,
+    ));
+    handle(embedder::embed_recent_chunks(conn, emb, 10, None));
+    if total > 0 {
+        info!(total, "Embedded chunks (nearby + recent)");
+    }
+}
+
+fn show_session(conn: &Connection, session_id: &str, verbose: bool) -> Result<CommandOutput> {
     let mut stmt = conn.prepare(
         "SELECT session_id, source, file_path, project, slug, timestamp \
          FROM sessions WHERE session_id LIKE ?1 ESCAPE '\\' ORDER BY session_id",
@@ -412,25 +443,41 @@ fn show_session(
         .query_map([&session.session_id], |row| Ok((row.get(0)?, row.get(1)?)))?
         .collect::<Result<_, _>>()?;
 
-    writeln!(w, "# {}", session.slug)?;
-    writeln!(w, "- session_id: {}", session.session_id)?;
-    writeln!(w, "- date: {}", format_timestamp(session.timestamp))?;
-    writeln!(w, "- project: {}", session.project)?;
-    writeln!(w, "- source: {}", session.source)?;
+    // Writes to an in-memory Vec are infallible; the pipe is only touched later
+    // by the single emit_success -> print_to_stdout.
+    let mut buf = Vec::new();
+    let _ = writeln!(buf, "# {}", session.slug);
+    let _ = writeln!(buf, "- session_id: {}", session.session_id);
+    let _ = writeln!(buf, "- date: {}", format_timestamp(session.timestamp));
+    let _ = writeln!(buf, "- project: {}", session.project);
+    let _ = writeln!(buf, "- source: {}", session.source);
     if verbose {
-        writeln!(w, "- file: {}", session.file_path)?;
+        let _ = writeln!(buf, "- file: {}", session.file_path);
     }
-    writeln!(w)?;
-
+    let _ = writeln!(buf);
     for (role, text) in &messages {
-        writeln!(w, "## [{role}]")?;
-        writeln!(w, "{text}")?;
-        writeln!(w)?;
+        let _ = writeln!(buf, "## [{role}]");
+        let _ = writeln!(buf, "{text}");
+        let _ = writeln!(buf);
     }
-    Ok(())
+    let markdown = String::from_utf8_lossy(&buf).into_owned();
+
+    let data = serde_json::json!({
+        "session_id": session.session_id,
+        "slug": session.slug,
+        "project": session.project,
+        "source": session.source.to_string(),
+        "timestamp": session.timestamp,
+        "messages": messages
+            .iter()
+            .map(|(role, text)| serde_json::json!({ "role": role, "text": text }))
+            .collect::<Vec<_>>(),
+    });
+
+    Ok(CommandOutput::ok(markdown, data))
 }
 
-fn run_show(session_id: &str, verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_show(session_id: &str, verbose: bool, db_path: &Option<PathBuf>) -> Result<CommandOutput> {
     let path = resolve_db_path(db_path)?;
     if !path.exists() {
         return Err(
@@ -439,25 +486,23 @@ fn run_show(session_id: &str, verbose: bool, db_path: &Option<PathBuf>) -> Resul
     }
 
     let conn = open_or_create_db(&path)?;
-    let mut w = io::stdout().lock();
-
-    if let Err(e) = show_session(&conn, session_id, verbose, &mut w) {
-        if let Some(io_err) = e.downcast_ref::<io::Error>()
-            && io_err.kind() == ErrorKind::BrokenPipe
-        {
-            process::exit(0);
-        }
-        return Err(e);
-    }
-    Ok(())
+    show_session(&conn, session_id, verbose)
 }
 
-fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
+fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<CommandOutput> {
     let path = resolve_db_path(db_path)?;
     if !path.exists() {
         cli_info(&format!("database not found at {}", path.display()));
         cli_info("run `recall index` to create the index.");
-        return Ok(());
+        return Ok(CommandOutput::ok(
+            String::new(),
+            serde_json::json!({
+                "sessions": 0,
+                "qa_chunks": 0,
+                "embedded": 0,
+                "model_ready": false,
+            }),
+        ));
     }
 
     let conn = open_or_create_db(&path)?;
@@ -470,8 +515,7 @@ fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
         .map(|opt| opt.is_some())
         .unwrap_or(false);
 
-    // Writes to an in-memory Vec are infallible, so the io::Result is discarded;
-    // the pipe is only touched by the single print_to_stdout below.
+    // Writes to an in-memory Vec are infallible, so the io::Result is discarded.
     let mut buf = Vec::new();
     let _ = writeln!(buf, "Sessions: {sessions}");
     let _ = writeln!(buf, "QA chunks: {chunks}");
@@ -488,9 +532,15 @@ fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<()> {
     if verbose {
         let _ = writeln!(buf, "DB: {}", path.display());
     }
-    print_to_stdout(&String::from_utf8_lossy(&buf));
+    let markdown = String::from_utf8_lossy(&buf).into_owned();
+    let data = serde_json::json!({
+        "sessions": sessions,
+        "qa_chunks": chunks,
+        "embedded": embedded,
+        "model_ready": model_ok,
+    });
 
-    Ok(())
+    Ok(CommandOutput::ok(markdown, data))
 }
 
 // -- Output formatting --
@@ -553,9 +603,9 @@ fn format_result(w: &mut impl Write, i: usize, r: &search::SearchResult) -> io::
 }
 
 /// Write fully-rendered `rendered` to stdout, stopping cleanly (exit 0) when the
-/// consumer closed the pipe early. Shared SIGPIPE boundary for the search/status
-/// result paths; `run_show` keeps its own (to be unified in Phase 2). See
-/// [`crate::output`].
+/// consumer closed the pipe early. The single SIGPIPE boundary for every result
+/// path (search/status/show, human or `--json`), reached via [`emit_success`].
+/// See [`crate::output`].
 fn print_to_stdout(rendered: &str) {
     match write_result(&mut io::stdout().lock(), rendered) {
         Ok(WriteOutcome::Written) => {}
@@ -580,8 +630,46 @@ fn render_results(results: &[search::SearchResult]) -> String {
     String::from_utf8_lossy(&buf).into_owned()
 }
 
-fn print_results(results: &[search::SearchResult]) {
-    print_to_stdout(&render_results(results));
+/// The machine payload for one search hit (#67 Phase 2), built explicitly so the
+/// `--json` schema stays decoupled from [`search::SearchResult`]'s internal
+/// shape (which is deliberately not `Serialize`).
+fn result_to_json(r: &search::SearchResult) -> serde_json::Value {
+    let s = &r.session;
+    serde_json::json!({
+        "session_id": s.session_id,
+        "project": s.project,
+        "slug": s.slug,
+        "source": s.source.to_string(),
+        "timestamp": s.timestamp,
+        "excerpt": r.excerpt,
+    })
+}
+
+/// Emit a command's result to stdout: the JSON success envelope when
+/// `json_mode`, else the human-readable markdown. Empty markdown (a side-effect
+/// command in text mode) prints nothing. Routes through [`print_to_stdout`] so
+/// the SIGPIPE boundary covers both modes.
+fn emit_success(out: &CommandOutput, json_mode: bool) {
+    let body = if json_mode {
+        render_json_success(out)
+    } else {
+        out.markdown.clone()
+    };
+    if !body.is_empty() {
+        print_to_stdout(&body);
+    }
+}
+
+/// Emit an error to stderr: the JSON error envelope when `json_mode`, else the
+/// human-readable `error: <msg>` line. The exit code is decided separately by
+/// [`classify_exit_code`], so the rendered shape and the exit code never
+/// disagree.
+fn emit_error(err: &anyhow::Error, json_mode: bool) {
+    if json_mode {
+        eprintln!("{}", render_json_error(&error_envelope(err)));
+    } else {
+        exit_error(&format!("{err:#}"));
+    }
 }
 
 // -- Entry point --
@@ -589,7 +677,7 @@ fn print_results(results: &[search::SearchResult]) {
 const KNOWN_SUBCOMMANDS: &[&str] = &[
     "index", "rebuild", "embed", "model", "search", "show", "status", "help",
 ];
-const GLOBAL_FLAGS: &[&str] = &["--verbose", "-v"];
+const GLOBAL_FLAGS: &[&str] = &["--verbose", "-v", "--json"];
 
 /// Parse argv into a [`Cli`], expanding shorthand first. Both expansion
 /// branches funnel through one `try_parse_from`, so a parse error prints once.
@@ -615,7 +703,15 @@ fn handle_parse_error(err: &clap::Error) -> ExitCode {
     }
 }
 
-fn run(cli: Cli) -> Result<()> {
+/// The [`CommandOutput`] for a side-effect command (index/embed/model): empty
+/// `markdown` and `null` `data`, since its progress already went to stderr. In
+/// `--json` mode [`emit_success`] still emits a `data: null` success envelope so
+/// an agent gets a parseable signal; in text mode it prints nothing.
+fn no_payload() -> CommandOutput {
+    CommandOutput::ok(String::new(), serde_json::Value::Null)
+}
+
+fn run(cli: Cli) -> Result<CommandOutput> {
     let default_filter = if cli.verbose {
         LOG_FILTER_VERBOSE
     } else {
@@ -624,10 +720,10 @@ fn run(cli: Cli) -> Result<()> {
     init_subscriber(default_filter);
 
     match cli.command {
-        Some(Command::Index) => run_index(&cli.db_path),
-        Some(Command::Rebuild) => run_rebuild(&cli.db_path),
-        Some(Command::Embed) => run_embed(&cli.db_path),
-        Some(Command::Model(ModelCommand::Download)) => run_model_download(),
+        Some(Command::Index) => run_index(&cli.db_path).map(|()| no_payload()),
+        Some(Command::Rebuild) => run_rebuild(&cli.db_path).map(|()| no_payload()),
+        Some(Command::Embed) => run_embed(&cli.db_path).map(|()| no_payload()),
+        Some(Command::Model(ModelCommand::Download)) => run_model_download().map(|()| no_payload()),
         Some(cmd @ Command::Search { .. }) => run_search(cmd, &cli.db_path),
         Some(Command::Show { session_id }) => run_show(&session_id, cli.verbose, &cli.db_path),
         Some(Command::Status) => run_status(cli.verbose, &cli.db_path),
@@ -645,11 +741,15 @@ fn main() -> ExitCode {
         Ok(cli) => cli,
         Err(code) => return code,
     };
+    let json_mode = cli.json;
 
     match run(cli) {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(out) => {
+            emit_success(&out, json_mode);
+            ExitCode::SUCCESS
+        }
         Err(e) => {
-            exit_error(&format!("{e:#}"));
+            emit_error(&e, json_mode);
             classify_exit_code(&e)
         }
     }
@@ -862,58 +962,52 @@ mod tests {
     #[test]
     fn test_show_session_exact_match() {
         let (_dir, conn) = setup_show_db();
-        let mut buf = Vec::new();
-        show_session(&conn, "abc-123", false, &mut buf).unwrap();
-        let output = String::from_utf8(buf).unwrap();
-        assert!(output.contains("# my-slug"));
-        assert!(output.contains("- session_id: abc-123"));
-        assert!(output.contains("- date: 2024-03-01"));
-        assert!(output.contains("## [user]\nhello world"));
-        assert!(output.contains("## [assistant]\nhi there"));
+        let out = show_session(&conn, "abc-123", false).unwrap();
+        assert!(out.markdown.contains("# my-slug"));
+        assert!(out.markdown.contains("- session_id: abc-123"));
+        assert!(out.markdown.contains("- date: 2024-03-01"));
+        assert!(out.markdown.contains("## [user]\nhello world"));
+        assert!(out.markdown.contains("## [assistant]\nhi there"));
+        // The `--json` payload carries the same session, machine-readable (#67 Phase 2).
+        assert_eq!(out.data["session_id"], "abc-123");
+        assert_eq!(out.data["messages"][0]["role"], "user");
+        assert_eq!(out.data["messages"][0]["text"], "hello world");
     }
 
     #[test]
     fn test_show_session_prefix_match() {
         let (_dir, conn) = setup_show_db();
-        let mut buf = Vec::new();
-        show_session(&conn, "abc-1", false, &mut buf).unwrap();
-        let output = String::from_utf8(buf).unwrap();
-        assert!(output.contains("- session_id: abc-123"));
+        let out = show_session(&conn, "abc-1", false).unwrap();
+        assert!(out.markdown.contains("- session_id: abc-123"));
     }
 
     #[test]
     fn test_show_session_ambiguous_prefix() {
         let (_dir, conn) = setup_show_db();
-        let mut buf = Vec::new();
-        let err = show_session(&conn, "abc", false, &mut buf).unwrap_err();
+        let err = show_session(&conn, "abc", false).unwrap_err();
         assert!(err.to_string().contains("Multiple sessions match"));
     }
 
     #[test]
     fn test_show_session_not_found() {
         let (_dir, conn) = setup_show_db();
-        let mut buf = Vec::new();
-        let err = show_session(&conn, "zzz", false, &mut buf).unwrap_err();
+        let err = show_session(&conn, "zzz", false).unwrap_err();
         assert!(err.to_string().contains("No session found matching"));
     }
 
     #[test]
     fn test_show_session_verbose_includes_file() {
         let (_dir, conn) = setup_show_db();
-        let mut buf = Vec::new();
-        show_session(&conn, "abc-123", true, &mut buf).unwrap();
-        let output = String::from_utf8(buf).unwrap();
-        assert!(output.contains("- file: /path/f.jsonl"));
+        let out = show_session(&conn, "abc-123", true).unwrap();
+        assert!(out.markdown.contains("- file: /path/f.jsonl"));
     }
 
     #[test]
     fn test_show_session_message_order() {
         let (_dir, conn) = setup_show_db();
-        let mut buf = Vec::new();
-        show_session(&conn, "abc-123", false, &mut buf).unwrap();
-        let output = String::from_utf8(buf).unwrap();
-        let user_pos = output.find("## [user]").unwrap();
-        let assistant_pos = output.find("## [assistant]").unwrap();
+        let out = show_session(&conn, "abc-123", false).unwrap();
+        let user_pos = out.markdown.find("## [user]").unwrap();
+        let assistant_pos = out.markdown.find("## [assistant]").unwrap();
         assert!(
             user_pos < assistant_pos,
             "user message should come before assistant"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1013,4 +1013,52 @@ mod tests {
             "user message should come before assistant"
         );
     }
+
+    /// Seed one session with one pending (un-embedded) chunk, the fixture both
+    /// `embed_around_results` tests share.
+    fn setup_pending_chunk_db() -> (tempfile::TempDir, Connection) {
+        let (dir, conn) = db::setup_test_db();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO qa_chunks (id, session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
+             VALUES (1, 's1', 'q', 'a', 'hello content', 0, 'h1')",
+            [],
+        )
+        .unwrap();
+        (dir, conn)
+    }
+
+    // T-EAR001: embed_around_results embeds the pending chunk near a hit session
+    // (the embedder-present side effect run_search runs after building its
+    // payload). Uses MockEmbedder because CI has no real embedding model.
+    #[test]
+    fn embed_around_results_embeds_pending_chunk() {
+        let (_dir, mut conn) = setup_pending_chunk_db();
+        let emb = embedder::MockEmbedder::new();
+        let results = [make_search_result("s1", "/p", "hello")];
+        embed_around_results(&mut conn, &emb, &results);
+        let embedded: i64 = conn
+            .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(embedded, 1, "the pending chunk should be embedded");
+    }
+
+    // T-EAR002: a failing embedder is swallowed — embed_around_results is
+    // best-effort background work, so it logs and returns (no panic, nothing
+    // embedded) and a search still succeeds when post-search embedding fails.
+    #[test]
+    fn embed_around_results_swallows_embed_failure() {
+        let (_dir, mut conn) = setup_pending_chunk_db();
+        let emb = embedder::MockEmbedder::failing_after(0);
+        let results = [make_search_result("s1", "/p", "hello")];
+        embed_around_results(&mut conn, &emb, &results);
+        let embedded: i64 = conn
+            .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(embedded, 0, "a failed embed must leave no vec_chunks");
+    }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -164,3 +164,216 @@ fn search_with_matching_index_lists_results() {
         "search stdout should list the matching session, got: {stdout}"
     );
 }
+
+// -- #67 Phase 2: global `--json` envelope (T-CLI011..T-CLI017) --
+//
+// These spawn the real binary with the global `--json` flag and pin the wire
+// envelope an agent consumes. Several assert on the response body, not the exit
+// code alone: a usage error (T-CLI012) exits 64, but a plain-text rejection
+// would too, so the `{"error":{"code":"USAGE_ERROR",...}}` body is what proves
+// the envelope path ran. The contract keys (`results`, `session_id`, `excerpt`,
+// `messages`, `sessions`, `qa_chunks`, `embedded`, `degraded`, `notes`) are the
+// public surface; assert them verbatim.
+
+/// Seed a one-session Claude index in `dir` so `--json` search has a hit to
+/// emit. Mirrors the T-CLI010 fixture (JSONL seed → `index` builds the DB);
+/// only `index` reads the source dir, so search then reads the built DB.
+fn seed_indexed_session(dir: &Path) {
+    let claude_dir = dir.join("claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("s1.jsonl"),
+        r#"{"type":"user","cwd":"/proj","message":{"role":"user","content":"hello world recall"},"timestamp":"2026-03-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        exit_code(
+            recall(dir)
+                .env("RECALL_CLAUDE_DIR", &claude_dir)
+                .arg("index")
+        ),
+        0,
+        "index should build the DB and exit 0"
+    );
+}
+
+// T-CLI011: `search <q> --json` against a matching index prints the success
+// envelope to stdout and exits 0. The machine path of the core OUTCOME (search
+// returns results): the data payload carries `results`, and each result row
+// carries `session_id` and `excerpt`. Perspective: normal (the JSON happy path).
+#[test]
+fn search_json_emits_success_envelope_with_results() {
+    let dir = TempDir::new().unwrap();
+    seed_indexed_session(dir.path());
+    let out = recall(dir.path())
+        .args(["search", "hello", "--no-embed", "--json"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "search --json should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(r#""data""#) && stdout.contains(r#""results""#),
+        "stdout should be a success envelope carrying results, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(r#""degraded""#) && stdout.contains(r#""notes""#),
+        "envelope should carry degraded + notes fields, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(r#""session_id""#) && stdout.contains(r#""excerpt""#),
+        "each result row should carry session_id and excerpt, got: {stdout}"
+    );
+}
+
+// T-CLI012: `--json` with no subcommand prints the usage error as a JSON
+// envelope on stderr and exits 64. Assert on the body, not the exit code alone:
+// today clap rejects the unknown `--json` flag with exit 64 too, so an exit-only
+// check would pass against plain-text stderr (a false green). The body must be
+// `{"error":{"code":"USAGE_ERROR",...}}` with a next_step. Perspective: error.
+#[test]
+fn no_subcommand_json_emits_error_envelope_on_stderr() {
+    let dir = TempDir::new().unwrap();
+    let out = recall(dir.path())
+        .arg("--json")
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(
+        out.status.code(),
+        Some(64),
+        "missing query is a usage error (64)"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(r#""error""#) && stderr.contains(r#""code":"USAGE_ERROR""#),
+        "stderr should be a JSON error envelope with USAGE_ERROR, got: {stderr}"
+    );
+    assert!(
+        stderr.contains(r#""next_step""#),
+        "the error envelope should carry next_step guidance, got: {stderr}"
+    );
+}
+
+// T-CLI013: `status --json` against a created index prints the stats as a
+// success envelope on stdout and exits 0. The data payload carries the
+// machine-readable counters (`sessions`, `qa_chunks`, `embedded`) — the
+// snake_case keys, not the human "Sessions:" / "QA chunks:" labels.
+// Perspective: normal.
+#[test]
+fn status_json_emits_stats_envelope() {
+    let dir = TempDir::new().unwrap();
+    // `index` creates the (empty) DB so `status` has counts to report.
+    assert_eq!(exit_code(recall(dir.path()).arg("index")), 0);
+    let out = recall(dir.path())
+        .args(["status", "--json"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "status --json should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(r#""data""#),
+        "stdout should be a success envelope, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(r#""sessions""#)
+            && stdout.contains(r#""qa_chunks""#)
+            && stdout.contains(r#""embedded""#),
+        "data should carry sessions/qa_chunks/embedded counters, got: {stdout}"
+    );
+}
+
+// T-CLI014: `--json` does not change the exit code of an empty-index search.
+// Searching an empty (but created) index is a success (exit 0) with or without
+// `--json` — the flag selects the output format, never the exit class.
+// Perspective: boundary (empty index, the zero-result edge) + regression (exit
+// code invariant across the flag). Pairs with T-CLI005 (the `--json`-less twin).
+#[test]
+fn search_empty_index_json_exit_code_matches_human() {
+    let human = TempDir::new().unwrap();
+    assert_eq!(exit_code(recall(human.path()).arg("index")), 0);
+    let human_code = exit_code(recall(human.path()).args(["search", "anything", "--no-embed"]));
+
+    let json = TempDir::new().unwrap();
+    assert_eq!(exit_code(recall(json.path()).arg("index")), 0);
+    let json_code =
+        exit_code(recall(json.path()).args(["search", "anything", "--no-embed", "--json"]));
+
+    assert_eq!(human_code, 0, "empty-index search (human) should exit 0");
+    assert_eq!(
+        json_code, human_code,
+        "--json must not change the exit code of an empty-index search"
+    );
+}
+
+// T-CLI015: without `--json`, search still prints the human-readable listing and
+// exits 0 — the Phase-2 envelope work must not regress the default output that
+// T-CLI010 pins. Regression guard: the same matching-index fixture must yield
+// the "Found N sessions:" text (not JSON) when `--json` is absent.
+#[test]
+fn search_without_json_keeps_human_output() {
+    let dir = TempDir::new().unwrap();
+    seed_indexed_session(dir.path());
+    let out = recall(dir.path())
+        .args(["search", "hello", "--no-embed"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "search should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Found 1 sessions:"),
+        "default output should stay human-readable, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains(r#""data""#),
+        "default output must not emit the JSON envelope, got: {stdout}"
+    );
+}
+
+// T-CLI016: `show <id> --json` against a matching index prints the success
+// envelope to stdout and exits 0. The data payload carries the session identity
+// (`session_id`) and the conversation as `messages` (each a role/text object) —
+// the machine path of `show`. Perspective: normal (the JSON happy path).
+#[test]
+fn show_json_emits_session_envelope() {
+    let dir = TempDir::new().unwrap();
+    seed_indexed_session(dir.path());
+    let out = recall(dir.path())
+        .args(["show", "s1", "--json"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "show --json should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(r#""data""#) && stdout.contains(r#""session_id":"s1""#),
+        "stdout should be a success envelope carrying the session id, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(r#""messages""#)
+            && stdout.contains(r#""role":"user""#)
+            && stdout.contains(r#""text":"hello world recall""#),
+        "data should carry the conversation messages, got: {stdout}"
+    );
+}
+
+// T-CLI017: without `--json`, `show` prints the human-readable markdown and
+// exits 0 — the envelope work must not regress the default `show` output. The
+// markdown carries the slug header and the role-tagged message body, and must
+// not emit the JSON envelope. Perspective: regression. Pairs with T-CLI016.
+#[test]
+fn show_without_json_keeps_human_output() {
+    let dir = TempDir::new().unwrap();
+    seed_indexed_session(dir.path());
+    let out = recall(dir.path())
+        .args(["show", "s1"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "show should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("# s1") && stdout.contains("## [user]"),
+        "default output should stay human-readable markdown, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains(r#""data""#),
+        "default output must not emit the JSON envelope, got: {stdout}"
+    );
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -199,8 +199,10 @@ fn seed_indexed_session(dir: &Path) {
 
 // T-CLI011: `search <q> --json` against a matching index prints the success
 // envelope to stdout and exits 0. The machine path of the core OUTCOME (search
-// returns results): the data payload carries `results`, and each result row
-// carries `session_id` and `excerpt`. Perspective: normal (the JSON happy path).
+// returns results): parses the envelope and asserts data.results carries the hit
+// (session_id + excerpt), and that degraded co-varies with notes — asserting the
+// invariant, not a fixed value, keeps it portable across machines that have or
+// lack the cached embedding model. Perspective: normal (the JSON happy path).
 #[test]
 fn search_json_emits_success_envelope_with_results() {
     let dir = TempDir::new().unwrap();
@@ -211,17 +213,34 @@ fn search_json_emits_success_envelope_with_results() {
         .expect("spawn recall binary");
     assert_eq!(out.status.code(), Some(0), "search --json should exit 0");
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        stdout.contains(r#""data""#) && stdout.contains(r#""results""#),
-        "stdout should be a success envelope carrying results, got: {stdout}"
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout should be one JSON envelope, got {stdout:?}: {e}"));
+    let results = v["data"]["results"]
+        .as_array()
+        .unwrap_or_else(|| panic!("data.results should be an array, got: {stdout}"));
+    assert_eq!(
+        results.len(),
+        1,
+        "the one seeded session should be the single hit, got: {stdout}"
     );
     assert!(
-        stdout.contains(r#""degraded""#) && stdout.contains(r#""notes""#),
-        "envelope should carry degraded + notes fields, got: {stdout}"
-    );
-    assert!(
-        stdout.contains(r#""session_id""#) && stdout.contains(r#""excerpt""#),
+        results[0]["session_id"].is_string() && results[0]["excerpt"].is_string(),
         "each result row should carry session_id and excerpt, got: {stdout}"
+    );
+    // degraded and notes co-vary: search sets degraded=true with an FTS-fallback
+    // note exactly when the embedding model is absent. Asserting the invariant
+    // (not a fixed value) keeps the test portable across machines that have or
+    // lack the cached model.
+    let degraded = v["degraded"]
+        .as_bool()
+        .unwrap_or_else(|| panic!("degraded should be a bool, got: {stdout}"));
+    let notes = v["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes should be an array, got: {stdout}"));
+    assert_eq!(
+        degraded,
+        !notes.is_empty(),
+        "degraded must coincide with a non-empty notes list, got: {stdout}"
     );
 }
 
@@ -375,5 +394,37 @@ fn show_without_json_keeps_human_output() {
     assert!(
         !stdout.contains(r#""data""#),
         "default output must not emit the JSON envelope, got: {stdout}"
+    );
+}
+
+// T-CLI018: a side-effect command (`index`) with `--json` emits the no_payload
+// envelope — data:null, degraded:false, empty notes — and exits 0. Pins the
+// machine contract for commands that produce no result payload (the only source
+// of `data:null` in the envelope). Progress spinners go to stderr, so stdout is
+// exactly the one envelope; parsed as JSON, not substring-matched.
+#[test]
+fn index_json_emits_null_data_envelope() {
+    let dir = TempDir::new().unwrap();
+    let out = recall(dir.path())
+        .args(["index", "--json"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "index --json should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout should be one JSON envelope, got {stdout:?}: {e}"));
+    assert!(
+        v["data"].is_null(),
+        "a side-effect command must emit data:null, got: {stdout}"
+    );
+    assert_eq!(
+        v["degraded"],
+        serde_json::json!(false),
+        "index is not a degraded path, got: {stdout}"
+    );
+    assert_eq!(
+        v["notes"],
+        serde_json::json!([]),
+        "index carries no notes, got: {stdout}"
     );
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -428,3 +428,33 @@ fn index_json_emits_null_data_envelope() {
         "index carries no notes, got: {stdout}"
     );
 }
+
+// T-CLI019: `status --json` against a never-created index reports zero counters
+// with model_ready:false as a success envelope, exit 0 — the no-database branch
+// of run_status. Pairs with T-CLI013, which runs `index` first (the live path).
+#[test]
+fn status_json_without_index_reports_zero_counts() {
+    let dir = TempDir::new().unwrap();
+    let out = recall(dir.path())
+        .args(["status", "--json"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "status --json should exit 0 without an index"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout should be one JSON envelope, got {stdout:?}: {e}"));
+    assert_eq!(
+        v["data"]["sessions"],
+        serde_json::json!(0),
+        "no index means zero sessions, got: {stdout}"
+    );
+    assert_eq!(
+        v["data"]["model_ready"],
+        serde_json::json!(false),
+        "the no-database branch reports model_ready:false, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## 概要

ADR-0060「agent-friendly CLI」#67 の Phase 2。全コマンドにグローバル `--json` フラグを追加し、機械可読エンベロープ・構造化エラー・degraded シグナルを配線する。Phase 1（PR #107、単一 SIGPIPE 境界 `print_to_stdout`）と #82/#103（exit code 分類）の上に構築。人間向け出力と exit code（ADR-0066 Group 2）は不変。ErrorCode の JSON 値は sae の共通語彙に整合（`Usage` → `UsageError` = `"USAGE_ERROR"`）。

## 変更点

- **src/envelope.rs（新規）**: `CommandOutput { markdown, data, degraded, notes }` を全 runner の戻り値型に。`SuccessEnvelope` / `ErrorEnvelope` / `ErrorPayload` の serde wire 型、`render_json_success` / `render_json_error`。`crate::error::ErrorCode` を再利用。
- **src/error.rs**: `ErrorCode` に `Serialize`（SCREAMING_SNAKE_CASE）+ `Usage` → `UsageError`。`RecallError::to_error_envelope`（next_step は variant 由来、retryable は TempFailure のみ）、`error_envelope`（downcast or classify）。
- **src/main.rs**: グローバル `--json`、`run_*` を `Result<CommandOutput>` 化、`emit_success` / `emit_error`、side-effect 用 `no_payload()`（data:null）、`run_search` から `embed_around_results` 抽出、`show` を Phase 1 SIGPIPE 境界へ統合。
- **tests/cli_integration.rs**: `--json` e2e T-CLI011..T-CLI018。

## 設計上の決定

- `data` は `json!()` で明示構築（内部型は非 `Serialize` 維持、公開スキーマを分離）
- `ErrorCode` は 1 enum 再利用。`RecallError::Usage` は tuple 維持、next_step は variant 由来（#82 のメッセージ依存回避）
- side-effect コマンドは `data:null` を emit。`degraded` は埋め込みモデル不在時のみ true

## テスト

unit 155 + integration 18 全 pass。clippy（`-D warnings`）/ fmt clean。envelope T-EN001..011、error T-ERR002..007、CLI e2e T-CLI011..018。

## 監査（/audit）

10 reviewer + critic-audit（反証）+ critic-evidence（検証）を実施。確定した高重大度欠陥なし（偽陽性率 33%）。`--json` 契約のカバレッジ欠如（side-effect の data:null、degraded 値、IoError 組立）を本 PR 内で修正（0949efb）。最大の収束警報「`--json` 出力汚染」は偽陽性（`done()`/`cli_info()` は stderr 出力、stdout JSON は非汚染）。

## スコープ外（後続）

- F13: SQLITE_BUSY/LOCKED → IoError `retryable=false`（エラー分類スコープ）
- F2: clap parse error の `--json` バイパス（SOW で envelope 化は任意）
- amici への envelope 昇格、candidates の実データ投入

Refs #67 (Phase 2)