### PR TITLE
write-only スキーマ列と embedded_chunk_ids を削除

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,15 +161,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,12 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,15 +425,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
-]
 
 [[package]]
 name = "daachorse"
@@ -583,17 +559,6 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
 ]
 
 [[package]]
@@ -969,12 +934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hf-hub"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,15 +995,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -1953,12 +1903,10 @@ dependencies = [
  "bytemuck",
  "clap",
  "dirs",
- "hex",
  "rurico",
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
  "tempfile",
  "thiserror",
  "tracing",
@@ -2287,17 +2235,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -2815,12 +2752,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,10 @@ anyhow = "1.0.102"
 bytemuck = "1"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 dirs = "6.0.0"
-hex = "0.4.3"
 rurico = { git = "https://github.com/thkt/rurico", rev = "a573655" }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-sha2 = "0.11.0"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -1,15 +1,10 @@
-use sha2::{Digest, Sha256};
-
 use crate::parser::{Message, Role};
 
 pub(crate) struct QAChunk {
     pub session_id: String,
-    pub user_text: String,
-    pub assistant_text: Option<String>,
     /// Embedding content: user_text [+ "\n" + assistant_text]. Prefix added by embedder.
     pub content: String,
     pub timestamp: Option<i64>,
-    pub chunk_hash: String,
 }
 
 /// Max content bytes per chunk (~4000-5000 tokens, well under model's 8192 limit).
@@ -79,12 +74,6 @@ fn find_split_boundary(text: &str, max_bytes: usize) -> usize {
     }
 }
 
-fn sha256_hex(s: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(s.as_bytes());
-    hex::encode(hasher.finalize())
-}
-
 /// Build Q&A chunks from a session's messages.
 ///
 /// Rules:
@@ -124,14 +113,10 @@ pub(crate) fn chunk_messages(
 
         let contents = build_content(&msg.text, assistant_text);
         for content in contents {
-            let chunk_hash = sha256_hex(&content);
             chunks.push(QAChunk {
                 session_id: session_id.to_owned(),
-                user_text: msg.text.clone(),
-                assistant_text: assistant_text.map(String::from),
                 content,
                 timestamp,
-                chunk_hash,
             });
         }
 
@@ -161,16 +146,10 @@ mod tests {
         let chunks = chunk_messages("s1", &messages, Some(1000));
 
         assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0].user_text, "認証フローについて教えて");
-        assert_eq!(
-            chunks[0].assistant_text.as_deref(),
-            Some("OAuth2を使う方法があります")
-        );
         assert!(chunks[0].content.contains("認証フロー"));
         assert!(chunks[0].content.contains("OAuth2"));
         assert_eq!(chunks[0].session_id, "s1");
         assert_eq!(chunks[0].timestamp, Some(1000));
-        assert!(!chunks[0].chunk_hash.is_empty());
     }
 
     #[test]
@@ -179,9 +158,8 @@ mod tests {
         let chunks = chunk_messages("s1", &messages, None);
 
         assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0].user_text, "最初の質問");
-        assert!(chunks[0].assistant_text.is_none());
-        assert_eq!(chunks[1].user_text, "次の質問");
+        assert_eq!(chunks[0].content, "最初の質問");
+        assert_eq!(chunks[1].content, "次の質問");
     }
 
     #[test]
@@ -211,12 +189,11 @@ mod tests {
         let chunks = chunk_messages("s1", &messages, Some(500));
 
         assert_eq!(chunks.len(), 3);
-        assert_eq!(chunks[0].user_text, "Q1");
-        assert_eq!(chunks[0].assistant_text.as_deref(), Some("A1"));
-        assert_eq!(chunks[1].user_text, "Q2");
-        assert!(chunks[1].assistant_text.is_none());
-        assert_eq!(chunks[2].user_text, "Q3");
-        assert_eq!(chunks[2].assistant_text.as_deref(), Some("A3"));
+        assert!(chunks[0].content.contains("Q1"));
+        assert!(chunks[0].content.contains("A1"));
+        assert_eq!(chunks[1].content, "Q2");
+        assert!(chunks[2].content.contains("Q3"));
+        assert!(chunks[2].content.contains("A3"));
     }
 
     #[test]
@@ -224,17 +201,6 @@ mod tests {
         let messages = vec![msg(Role::User, ""), msg(Role::Assistant, "answer")];
         let chunks = chunk_messages("s1", &messages, None);
         assert!(chunks.is_empty());
-    }
-
-    #[test]
-    fn test_chunk_hash_deterministic() {
-        let messages = vec![msg(Role::User, "same question")];
-        let c1 = chunk_messages("s1", &messages, None);
-        let c2 = chunk_messages("s2", &messages, None);
-        assert_eq!(
-            c1[0].chunk_hash, c2[0].chunk_hash,
-            "same content → same hash"
-        );
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -34,6 +34,12 @@ fn create_schema(conn: &mut Connection) -> Result<()> {
 
     migrate_fts_if_needed(conn)?;
     migrate_vec_chunks_if_needed(conn)?;
+    migrate_qa_chunks_if_needed(conn)?;
+
+    // embedded_chunk_ids (a removed ledger) was dropped inside two separate
+    // migrations; collapse those into one unconditional drop so every pre-cleanup
+    // DB ends up without it after open_db.
+    conn.execute_batch("DROP TABLE IF EXISTS embedded_chunk_ids;")?;
 
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project);
@@ -53,14 +59,10 @@ fn create_schema(conn: &mut Connection) -> Result<()> {
         "CREATE TABLE IF NOT EXISTS qa_chunks (
             id INTEGER PRIMARY KEY,
             session_id TEXT NOT NULL,
-            user_text TEXT NOT NULL,
-            assistant_text TEXT,
             content TEXT NOT NULL,
-            timestamp INTEGER,
-            chunk_hash TEXT NOT NULL
+            timestamp INTEGER
         );
-        CREATE INDEX IF NOT EXISTS idx_qa_chunks_session ON qa_chunks(session_id);
-        CREATE INDEX IF NOT EXISTS idx_qa_chunks_hash ON qa_chunks(chunk_hash);",
+        CREATE INDEX IF NOT EXISTS idx_qa_chunks_session ON qa_chunks(session_id);",
     )?;
 
     conn.execute_batch(&format!(
@@ -72,42 +74,58 @@ fn create_schema(conn: &mut Connection) -> Result<()> {
     ))?;
 
     conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS embedded_chunk_ids (
-            chunk_id INTEGER NOT NULL,
-            sub_idx INTEGER NOT NULL,
-            vec_rowid INTEGER NOT NULL,
-            PRIMARY KEY (chunk_id, sub_idx)
-        );
-        CREATE INDEX IF NOT EXISTS idx_embedded_chunk_ids_chunk ON embedded_chunk_ids(chunk_id);",
-    )?;
-
-    conn.execute_batch(
         "CREATE VIRTUAL TABLE IF NOT EXISTS messages_vocab USING fts5vocab(messages, row);",
     )?;
 
     Ok(())
 }
 
-fn migrate_vec_chunks_if_needed(conn: &mut Connection) -> Result<()> {
-    let sql: Option<String> = match conn.query_row(
-        "SELECT sql FROM sqlite_master WHERE type='table' AND name='vec_chunks'",
-        [],
+/// Fetch a table's stored `CREATE` SQL from `sqlite_master`, or `None` if it
+/// does not exist. Virtual tables (fts5, vec0) are stored with `type='table'`,
+/// so this resolves regular and virtual tables alike.
+fn table_def(conn: &Connection, name: &str) -> Result<Option<String>> {
+    match conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name=?1",
+        [name],
         |r| r.get(0),
     ) {
-        Ok(sql) => Some(sql),
-        Err(rusqlite::Error::QueryReturnedNoRows) => None,
-        Err(e) => return Err(e.into()),
-    };
+        Ok(sql) => Ok(Some(sql)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
 
-    let Some(sql) = sql else {
+fn migrate_vec_chunks_if_needed(conn: &mut Connection) -> Result<()> {
+    let Some(sql) = table_def(conn, "vec_chunks")? else {
         return Ok(());
     };
 
     if !sql.contains("sub_idx") {
         notify_schema_change("recall", "embeddings", 0, "recall embed");
         let tx = conn.transaction()?;
+        tx.execute_batch("DROP TABLE IF EXISTS vec_chunks;")?;
+        tx.commit()?;
+    }
+
+    Ok(())
+}
+
+/// Drop the write-only columns (chunk_hash / user_text / assistant_text) from
+/// pre-cleanup databases. ALTER ... DROP COLUMN keeps content / id and the
+/// vec_chunks linkage by chunk_id intact, so existing embeddings survive without
+/// a re-index. The removed embedded_chunk_ids ledger is dropped in create_schema.
+fn migrate_qa_chunks_if_needed(conn: &mut Connection) -> Result<()> {
+    let Some(sql) = table_def(conn, "qa_chunks")? else {
+        return Ok(());
+    };
+
+    if sql.contains("chunk_hash") {
+        let tx = conn.transaction()?;
         tx.execute_batch(
-            "DROP TABLE IF EXISTS vec_chunks; DROP TABLE IF EXISTS embedded_chunk_ids;",
+            "DROP INDEX IF EXISTS idx_qa_chunks_hash;
+             ALTER TABLE qa_chunks DROP COLUMN chunk_hash;
+             ALTER TABLE qa_chunks DROP COLUMN user_text;
+             ALTER TABLE qa_chunks DROP COLUMN assistant_text;",
         )?;
         tx.commit()?;
     }
@@ -116,17 +134,7 @@ fn migrate_vec_chunks_if_needed(conn: &mut Connection) -> Result<()> {
 }
 
 fn migrate_fts_if_needed(conn: &mut Connection) -> Result<()> {
-    let sql: Option<String> = match conn.query_row(
-        "SELECT sql FROM sqlite_master WHERE type='table' AND name='messages'",
-        [],
-        |r| r.get(0),
-    ) {
-        Ok(sql) => Some(sql),
-        Err(rusqlite::Error::QueryReturnedNoRows) => None,
-        Err(e) => return Err(e.into()),
-    };
-
-    let Some(sql) = sql else {
+    let Some(sql) = table_def(conn, "messages")? else {
         return Ok(());
     };
 
@@ -157,6 +165,7 @@ pub(crate) fn setup_test_db() -> (tempfile::TempDir, Connection) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::embedder::f32_as_bytes;
     use tempfile::NamedTempFile;
 
     #[test]
@@ -280,5 +289,135 @@ mod tests {
             chunks, 0,
             "qa_chunks should be cleared by migration cascade"
         );
+    }
+
+    /// Build a DB with the pre-cleanup qa_chunks schema (chunk_hash / user_text /
+    /// assistant_text + idx_qa_chunks_hash), an embedded_chunk_ids table, and a
+    /// vec_chunks row linked by chunk_id. Uses the trigram tokenizer and the
+    /// sub_idx vec schema so neither migrate_fts_if_needed nor
+    /// migrate_vec_chunks_if_needed fires (both would wipe qa_chunks/vec_chunks).
+    fn create_pre_cleanup_db(path: &Path) {
+        ensure_sqlite_vec().map_err(|e| anyhow::anyhow!(e)).unwrap();
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(&format!(
+            "CREATE TABLE sessions (
+                session_id TEXT PRIMARY KEY, source TEXT, file_path TEXT,
+                project TEXT, slug TEXT, timestamp INTEGER, mtime REAL
+            );
+            CREATE VIRTUAL TABLE messages USING fts5(
+                session_id UNINDEXED, role, text, tokenize='{FTS_TOKENIZER}'
+            );
+            CREATE TABLE qa_chunks (
+                id INTEGER PRIMARY KEY, session_id TEXT NOT NULL,
+                user_text TEXT NOT NULL, assistant_text TEXT,
+                content TEXT NOT NULL, timestamp INTEGER, chunk_hash TEXT NOT NULL
+            );
+            CREATE INDEX idx_qa_chunks_hash ON qa_chunks(chunk_hash);
+            CREATE TABLE embedded_chunk_ids (
+                chunk_id INTEGER NOT NULL, sub_idx INTEGER NOT NULL,
+                vec_rowid INTEGER NOT NULL, PRIMARY KEY (chunk_id, sub_idx)
+            );
+            CREATE VIRTUAL TABLE vec_chunks USING vec0(
+                embedding FLOAT[{EMBEDDING_DIMS}], +chunk_id INTEGER, +sub_idx INTEGER
+            );"
+        ))
+        .unwrap();
+        conn.execute(
+            "INSERT INTO qa_chunks (id, session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
+             VALUES (1, 's1', 'q', 'a', 'q\na', 0, 'deadbeef')",
+            [],
+        )
+        .unwrap();
+        let emb = vec![0.1f32; EMBEDDING_DIMS];
+        conn.execute(
+            "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, 1, 0)",
+            [f32_as_bytes(&emb)],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO embedded_chunk_ids (chunk_id, sub_idx, vec_rowid) VALUES (1, 0, 1)",
+            [],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_qa_chunks_migration_drops_write_only_columns_preserving_embeddings() {
+        let tmp = NamedTempFile::new().unwrap();
+        create_pre_cleanup_db(tmp.path());
+
+        let conn = open_db(tmp.path()).unwrap();
+
+        // (a) write-only columns are gone
+        let cols: Vec<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(qa_chunks)").unwrap();
+            stmt.query_map([], |r| r.get::<_, String>(1))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap()
+        };
+        for gone in ["chunk_hash", "user_text", "assistant_text"] {
+            assert!(
+                !cols.contains(&gone.to_owned()),
+                "column {gone} should be dropped, got {cols:?}"
+            );
+        }
+
+        // (b) content + id preserved
+        let (id, content): (i64, String) = conn
+            .query_row("SELECT id, content FROM qa_chunks WHERE id = 1", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(content, "q\na");
+
+        // (c) vec_chunks row preserved and still linked by chunk_id (embedding not orphaned)
+        let vec_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM vec_chunks v JOIN qa_chunks c ON c.id = v.chunk_id",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            vec_count, 1,
+            "vec_chunks row must survive and stay linked to qa_chunks"
+        );
+
+        // (d) embedded_chunk_ids table is gone
+        let tbl: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='embedded_chunk_ids'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(tbl, 0, "embedded_chunk_ids table should be dropped");
+
+        // Idempotency: re-opening an already-migrated DB must be a no-op, not
+        // re-run or error. This is the path every returning user hits on their
+        // next `recall`, so the chunk_hash sniff must stay false after migration.
+        drop(conn);
+        let conn = open_db(tmp.path()).unwrap();
+        let cols2: Vec<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(qa_chunks)").unwrap();
+            stmt.query_map([], |r| r.get::<_, String>(1))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap()
+        };
+        assert!(
+            !cols2.contains(&"chunk_hash".to_owned()),
+            "re-open must stay migrated, got {cols2:?}"
+        );
+        let vec_count2: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM vec_chunks v JOIN qa_chunks c ON c.id = v.chunk_id",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(vec_count2, 1, "re-open must keep vec row linked");
     }
 }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -63,12 +63,6 @@ fn embed_chunks(
                              VALUES (?1, ?2, ?3)",
                             rusqlite::params![embedding_bytes, chunks[i].0, sub_idx as i64],
                         )?;
-                        let vec_rowid = tx.last_insert_rowid();
-                        tx.execute(
-                            "INSERT INTO embedded_chunk_ids (chunk_id, sub_idx, vec_rowid) \
-                             VALUES (?1, ?2, ?3)",
-                            rusqlite::params![chunks[i].0, sub_idx as i64, vec_rowid],
-                        )?;
                     }
                 }
                 tx.commit()?;
@@ -253,9 +247,9 @@ mod tests {
         .unwrap();
         for i in 0..3 {
             conn.execute(
-                "INSERT INTO qa_chunks (id, session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
-                 VALUES (?1, 's1', 'q', 'a', ?2, 0, ?3)",
-                rusqlite::params![i + 1, format!("content {i}"), format!("hash{i}")],
+                "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+                 VALUES (?1, 's1', ?2, 0)",
+                rusqlite::params![i + 1, format!("content {i}")],
             )
             .unwrap();
         }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -471,16 +471,8 @@ pub(crate) fn index_chunks(conn: &mut Connection) -> Result<ChunkStats> {
 
         for chunk in &chunks {
             tx.execute(
-                "INSERT INTO qa_chunks (session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                rusqlite::params![
-                    chunk.session_id,
-                    chunk.user_text,
-                    chunk.assistant_text,
-                    chunk.content,
-                    chunk.timestamp,
-                    chunk.chunk_hash,
-                ],
+                "INSERT INTO qa_chunks (session_id, content, timestamp) VALUES (?1, ?2, ?3)",
+                rusqlite::params![chunk.session_id, chunk.content, chunk.timestamp],
             )?;
             chunks_created += 1;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1024,8 +1024,8 @@ mod tests {
         )
         .unwrap();
         conn.execute(
-            "INSERT INTO qa_chunks (id, session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
-             VALUES (1, 's1', 'q', 'a', 'hello content', 0, 'h1')",
+            "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+             VALUES (1, 's1', 'hello content', 0)",
             [],
         )
         .unwrap();

--- a/src/search.rs
+++ b/src/search.rs
@@ -523,9 +523,8 @@ mod tests {
         ts: i64,
     ) {
         conn.execute(
-            "INSERT INTO qa_chunks (id, session_id, user_text, assistant_text, content, timestamp, chunk_hash) \
-             VALUES (?1, ?2, 'q', 'a', ?3, ?4, ?5)",
-            rusqlite::params![chunk_id, sid, text, ts, format!("hash{chunk_id}")],
+            "INSERT INTO qa_chunks (id, session_id, content, timestamp) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![chunk_id, sid, text, ts],
         )
         .unwrap();
         let embedding = MockEmbedder::deterministic_vector(text);


### PR DESCRIPTION
## 概要

#53 / #71 / #72。書き込み専用になっていた schema を削除する。検索でも `recall show` でも読まれない列・テーブルを撤去し、`content` と `vec_chunks` の紐付け（chunk_id）は保持するため、蓄積済み embedding は再 index 不要で残る。

## 変更内容

- `qa_chunks` から `chunk_hash` / `user_text` / `assistant_text` を削除（残るのは `id` / `session_id` / `content` / `timestamp`）
- `embedded_chunk_ids` テーブルを撤去
- `migrate_qa_chunks_if_needed` を追加: 既存 DB を `chunk_hash` で sniff し、`ALTER TABLE DROP COLUMN` で破壊せず移行。`content` と chunk_id 紐付けを保つので embedding は再 index されない
- `sha2` / `hex` 依存を削除（唯一の利用箇所だった `sha256_hex` を撤去、Cargo.lock -69行）
- （polish）`table_def(conn, name)` を抽出して3箇所の重複 prologue を集約し、`embedded_chunk_ids` の DROP を `create_schema` の無条件1文に集約（各 migration が単一責任に）

## テスト

- `test_qa_chunks_migration_drops_write_only_columns_preserving_embeddings`: 旧 schema DB を仕込み、列削除・`content`/`id` 保持・`vec_chunks` JOIN による embedding 非孤立・`embedded_chunk_ids` 撤去・再 open の冪等性を検証
- 176 tests passed / clippy `-D warnings` / fmt 全 green

## レビュー重点

マイグレーションが `vec_chunks` ↔ `qa_chunks` の chunk_id 紐付けを保持し、蓄積済み embedding が再 index 不要で残ること。`ALTER DROP COLUMN` は SQLite 3.50（bundled）で動作。

## follow-up

並行 embed 時の `vec_chunks` 重複（`embedded_chunk_ids` PK が担っていた incidental な重複ガードの喪失）は #111 へ分離。検索結果は `GROUP BY session_id` で吸収されユーザー不可視のため本 PR では対応しない。

Closes #53, #71, #72
