### PR TITLE
CLAUDE_CODE_SESSION_ID で「現在 session」を識別・除外

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,19 @@ enum Command {
         /// Skip post-search embedding (faster for piped/scripted usage)
         #[arg(long)]
         no_embed: bool,
+
+        /// Exclude the invoking Claude Code session from results. Default when
+        /// CLAUDE_CODE_SESSION_ID is set (recall run from inside a session).
+        #[arg(long, conflicts_with_all = ["include_current", "only_current"])]
+        exclude_current: bool,
+
+        /// Include the invoking session even when CLAUDE_CODE_SESSION_ID is set.
+        #[arg(long, conflicts_with_all = ["exclude_current", "only_current"])]
+        include_current: bool,
+
+        /// Return only the invoking session (requires CLAUDE_CODE_SESSION_ID).
+        #[arg(long, conflicts_with_all = ["exclude_current", "include_current"])]
+        only_current: bool,
     },
     /// Show full conversation of a session
     Show {
@@ -299,6 +312,54 @@ fn search_idle_message(session_count: i64) -> Option<&'static str> {
     (session_count == 0).then_some("No sessions indexed. Run `recall index` first.")
 }
 
+/// The three mutually exclusive `--*-current` flags, grouped so
+/// `resolve_current_session` takes one argument instead of three booleans.
+#[derive(Clone, Copy, Debug)]
+struct CurrentSessionFlags {
+    exclude: bool,
+    include: bool,
+    only: bool,
+}
+
+/// Resolve how `recall search` treats the invoking session, from the
+/// `--*-current` flags and the `CLAUDE_CODE_SESSION_ID` env value (read by the
+/// caller and passed in, so the truth table is testable without touching process
+/// env). With no flag, an env id present defaults to excluding the current
+/// session: an agent searching mid-session does not want its own in-progress
+/// transcript echoed back. A blank (empty or whitespace-only) env value is
+/// treated as absent, so `--only-current` still reports the usage error instead
+/// of silently matching no session.
+fn resolve_current_session(
+    flags: CurrentSessionFlags,
+    env_session_id: Option<String>,
+) -> Result<search::CurrentSession, RecallError> {
+    use search::CurrentSession;
+    // A set-but-blank env value (e.g. exported empty in a shell) is not a usable
+    // session id; treat it as absent so every mode below behaves consistently.
+    let env_session_id = env_session_id.filter(|s| !s.trim().is_empty());
+    if flags.only {
+        return match env_session_id {
+            Some(id) => Ok(CurrentSession::Only(id)),
+            None => Err(RecallError::Usage(
+                "--only-current requires CLAUDE_CODE_SESSION_ID; run recall from inside a Claude Code session"
+                    .to_owned(),
+            )),
+        };
+    }
+    if flags.include {
+        return Ok(CurrentSession::Ignore);
+    }
+    match env_session_id {
+        Some(id) => Ok(CurrentSession::Exclude(id)),
+        None => {
+            if flags.exclude {
+                warn!("--exclude-current has no effect: CLAUDE_CODE_SESSION_ID is not set");
+            }
+            Ok(CurrentSession::Ignore)
+        }
+    }
+}
+
 fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<CommandOutput> {
     let Command::Search {
         query,
@@ -307,10 +368,22 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<CommandOutput> 
         source,
         limit,
         no_embed,
+        exclude_current,
+        include_current,
+        only_current,
     } = cmd
     else {
         unreachable!()
     };
+
+    let current = resolve_current_session(
+        CurrentSessionFlags {
+            exclude: exclude_current,
+            include: include_current,
+            only: only_current,
+        },
+        env::var("CLAUDE_CODE_SESSION_ID").ok(),
+    )?;
 
     let path = resolve_db_path(db_path)?;
     let mut conn = open_or_create_db(&path)?;
@@ -348,6 +421,7 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<CommandOutput> 
             days,
             source,
             limit: limit.into(),
+            current,
             now_ms: None,
         },
         embedder.as_deref(),
@@ -758,6 +832,67 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // T-CS001: resolve_current_session is the single place the env-exclude policy
+    // lives, so this (flags x env) truth table is the contract.
+    #[test]
+    fn resolve_current_session_truth_table() {
+        use search::CurrentSession;
+        let flags = |exclude, include, only| CurrentSessionFlags {
+            exclude,
+            include,
+            only,
+        };
+        let with_env = || Some("sess-x".to_owned());
+        let exclude_x = || CurrentSession::Exclude("sess-x".to_owned());
+
+        // no flag: env present → default-exclude; env absent → ignore
+        assert_eq!(
+            resolve_current_session(flags(false, false, false), with_env()).unwrap(),
+            exclude_x()
+        );
+        assert_eq!(
+            resolve_current_session(flags(false, false, false), None).unwrap(),
+            CurrentSession::Ignore
+        );
+        // --exclude-current: env present → exclude; env absent → ignore (warns, no-op)
+        assert_eq!(
+            resolve_current_session(flags(true, false, false), with_env()).unwrap(),
+            exclude_x()
+        );
+        assert_eq!(
+            resolve_current_session(flags(true, false, false), None).unwrap(),
+            CurrentSession::Ignore
+        );
+        // --include-current: ignore regardless of env
+        assert_eq!(
+            resolve_current_session(flags(false, true, false), with_env()).unwrap(),
+            CurrentSession::Ignore
+        );
+        assert_eq!(
+            resolve_current_session(flags(false, true, false), None).unwrap(),
+            CurrentSession::Ignore
+        );
+        // --only-current: env present → only; env absent → usage error
+        assert_eq!(
+            resolve_current_session(flags(false, false, true), with_env()).unwrap(),
+            CurrentSession::Only("sess-x".to_owned())
+        );
+        assert!(
+            resolve_current_session(flags(false, false, true), None).is_err(),
+            "--only-current without CLAUDE_CODE_SESSION_ID must be a usage error"
+        );
+        // a blank (empty/whitespace) env value is treated as absent
+        assert_eq!(
+            resolve_current_session(flags(false, false, false), Some("  ".to_owned())).unwrap(),
+            CurrentSession::Ignore,
+            "blank CLAUDE_CODE_SESSION_ID must not produce a degenerate Exclude"
+        );
+        assert!(
+            resolve_current_session(flags(false, false, true), Some(String::new())).is_err(),
+            "--only-current with a blank env value must still be a usage error"
+        );
+    }
 
     #[test]
     fn test_format_timestamp() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -27,11 +27,30 @@ pub struct SearchResult {
     pub excerpt: String,
 }
 
+/// How `recall search` treats the session that invoked it.
+///
+/// Resolved by the CLI layer from `CLAUDE_CODE_SESSION_ID` and the
+/// `--{exclude,include,only}-current` flags. The library default is `Ignore`, so
+/// existing search behavior is unchanged unless a caller opts in — the env-based
+/// exclude policy lives only in the CLI (`resolve_current_session`), never here.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum CurrentSession {
+    /// No current-session filtering.
+    #[default]
+    Ignore,
+    /// Drop results whose session id equals this value (the invoking session).
+    Exclude(String),
+    /// Return only results whose session id equals this value.
+    Only(String),
+}
+
 pub struct SearchOptions {
     pub project: Option<String>,
     pub days: Option<i64>,
     pub source: Option<Source>,
     pub limit: usize,
+    /// How to treat the invoking session (see `CurrentSession`).
+    pub current: CurrentSession,
     /// Override current time (epoch ms) for deterministic testing.
     pub now_ms: Option<i64>,
 }
@@ -43,6 +62,7 @@ impl Default for SearchOptions {
             days: None,
             source: None,
             limit: 10,
+            current: CurrentSession::Ignore,
             now_ms: None,
         }
     }
@@ -80,6 +100,29 @@ fn append_session_filter(
     sql.push(')');
 }
 
+/// Append ` AND {column} <> ?` (Exclude) or ` AND {column} = ?` (Only) for the
+/// invoking session; `Ignore` emits nothing. Called unconditionally on both the
+/// FTS and vec candidate queries so an excluded session cannot slip back in via
+/// the path that skipped filtering — the RRF merge re-unions both candidate sets,
+/// so a single-path filter would leak. Precondition matches
+/// `append_session_filter`: `sql` ends inside an open WHERE clause.
+fn append_current_session_filter(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn ToSql>>,
+    column: &'static str,
+    current: &CurrentSession,
+) {
+    let (op, id) = match current {
+        CurrentSession::Ignore => return,
+        CurrentSession::Exclude(id) => (" <> ?", id),
+        CurrentSession::Only(id) => (" = ?", id),
+    };
+    sql.push_str(" AND ");
+    sql.push_str(column);
+    sql.push_str(op);
+    params.push(Box::new(id.clone()));
+}
+
 fn build_fts_candidate_query(
     fts_query: &str,
     opts: &SearchOptions,
@@ -89,6 +132,7 @@ fn build_fts_candidate_query(
         "SELECT session_id, MIN(rank) as best_rank FROM messages WHERE messages MATCH ?".to_owned();
     let mut params: Vec<Box<dyn ToSql>> = vec![Box::new(fts_query.to_owned())];
     append_session_filter(&mut sql, &mut params, "session_id", opts, now_ms);
+    append_current_session_filter(&mut sql, &mut params, "session_id", &opts.current);
     sql.push_str(" GROUP BY session_id ORDER BY best_rank LIMIT ?");
     let candidate_limit = opts.limit * 3;
     params.push(Box::new(candidate_limit as i64));
@@ -342,6 +386,7 @@ fn vec_search(
     );
     let mut filter_params: Vec<Box<dyn ToSql>> = Vec::new();
     append_session_filter(&mut sql, &mut filter_params, "c.session_id", opts, now_ms);
+    append_current_session_filter(&mut sql, &mut filter_params, "c.session_id", &opts.current);
     sql.push_str(" GROUP BY c.session_id ORDER BY d");
 
     let limit_i64 = limit as i64;
@@ -1176,6 +1221,99 @@ mod tests {
             .into_iter()
             .map(|r| r.session.session_id)
             .collect()
+    }
+
+    // T-CS002: CurrentSession::Exclude drops the invoking session from BOTH the
+    // FTS and vec candidate paths. The excluded session is seeded into messages
+    // (FTS hit) and vec_chunks (vec hit); if the filter were applied on only one
+    // path, the RRF merge would re-union it from the unfiltered path.
+    // assert_filter_symmetric proves it is absent from the merged output while the
+    // other session survives. This is the load-bearing both-paths guard for #77.
+    // `cur` is intentionally in both paths (not vec-only): that way deleting the
+    // filter call on EITHER builder resurfaces it. The vec path's own liveness is
+    // independently covered by test_hybrid_search_merges_fts_and_vector.
+    #[test]
+    fn test_hybrid_exclude_current_drops_session_from_both_paths() {
+        let (_dir, conn) = setup_test_db();
+        let now_ms = 1_750_000_000_000_i64;
+        let embedder = MockEmbedder::new();
+
+        assert_filter_symmetric(
+            || {
+                insert_session(&conn, "keep", "claude", "/proj", now_ms);
+                insert_message(&conn, "keep", "user", "authentication flow discussion");
+                // `cur` is the invoking session: it matches on BOTH paths.
+                insert_session(&conn, "cur", "claude", "/proj", now_ms);
+                insert_message(&conn, "cur", "user", "authentication flow discussion");
+                insert_chunk_with_embedding(&conn, 1, "cur", "authentication", now_ms);
+                ("keep".to_owned(), "cur".to_owned())
+            },
+            || {
+                hybrid_search_ids(
+                    &conn,
+                    &embedder,
+                    &SearchOptions {
+                        current: CurrentSession::Exclude("cur".to_owned()),
+                        now_ms: Some(now_ms),
+                        ..Default::default()
+                    },
+                )
+            },
+            || {
+                hybrid_search_ids(
+                    &conn,
+                    &embedder,
+                    &SearchOptions {
+                        now_ms: Some(now_ms),
+                        ..Default::default()
+                    },
+                )
+            },
+        );
+    }
+
+    // T-CS003: CurrentSession::Only keeps only the invoking session. `keep`
+    // matches on both paths but must be dropped; `cur` carries an FTS match and
+    // survives. The `= ?` arm filters both candidate paths (both-paths rationale:
+    // T-CS002).
+    #[test]
+    fn test_hybrid_only_current_keeps_only_invoking_session() {
+        let (_dir, conn) = setup_test_db();
+        let now_ms = 1_750_000_000_000_i64;
+        let embedder = MockEmbedder::new();
+
+        assert_filter_symmetric(
+            || {
+                insert_session(&conn, "cur", "claude", "/proj", now_ms);
+                insert_message(&conn, "cur", "user", "authentication flow discussion");
+                // `keep` matches on BOTH paths but must be dropped by Only("cur").
+                insert_session(&conn, "keep", "claude", "/proj", now_ms);
+                insert_message(&conn, "keep", "user", "authentication flow discussion");
+                insert_chunk_with_embedding(&conn, 1, "keep", "authentication", now_ms);
+                ("cur".to_owned(), "keep".to_owned())
+            },
+            || {
+                hybrid_search_ids(
+                    &conn,
+                    &embedder,
+                    &SearchOptions {
+                        current: CurrentSession::Only("cur".to_owned()),
+                        now_ms: Some(now_ms),
+                        ..Default::default()
+                    },
+                )
+            },
+            || {
+                hybrid_search_ids(
+                    &conn,
+                    &embedder,
+                    &SearchOptions {
+                        now_ms: Some(now_ms),
+                        ..Default::default()
+                    },
+                )
+            },
+        );
     }
 
     #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -10,12 +10,17 @@ use tempfile::TempDir;
 
 /// A `recall` invocation isolated from the developer's real sessions and DB.
 /// `RECALL_DB` points at a path inside `dir`; the source dirs point nowhere so
-/// indexing never touches `~/.claude` or `~/.codex`.
+/// indexing never touches `~/.claude` or `~/.codex`. `CLAUDE_CODE_SESSION_ID` is
+/// cleared so a suite run from inside a live Claude Code session does not inherit
+/// the invoking session id — `search` now excludes that session by default, so
+/// inheritance would leak the runner's environment into results. Tests that
+/// exercise the exclusion set the variable explicitly.
 fn recall(dir: &Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_recall"));
     cmd.env("RECALL_DB", dir.join("recall.db"))
         .env("RECALL_CLAUDE_DIR", dir.join("no-claude"))
-        .env("RECALL_CODEX_DIR", dir.join("no-codex"));
+        .env("RECALL_CODEX_DIR", dir.join("no-codex"))
+        .env_remove("CLAUDE_CODE_SESSION_ID");
     cmd
 }
 
@@ -456,5 +461,129 @@ fn status_json_without_index_reports_zero_counts() {
         v["data"]["model_ready"],
         serde_json::json!(false),
         "the no-database branch reports model_ready:false, got: {stdout}"
+    );
+}
+
+/// Seed a two-session Claude index (s1, s2) that both match "hello", then index
+/// it. The current-session tests differ only in the flag and env they pass next,
+/// so the seed lives here once.
+fn seed_two_matching_sessions(dir: &Path) {
+    let claude_dir = dir.join("claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    for sid in ["s1", "s2"] {
+        fs::write(
+            claude_dir.join(format!("{sid}.jsonl")),
+            r#"{"type":"user","cwd":"/proj","message":{"role":"user","content":"hello world recall"},"timestamp":"2026-03-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+    }
+    assert_eq!(
+        exit_code(
+            recall(dir)
+                .env("RECALL_CLAUDE_DIR", &claude_dir)
+                .arg("index")
+        ),
+        0,
+        "index should build the DB and exit 0"
+    );
+}
+
+// T-CLI020: CLAUDE_CODE_SESSION_ID excludes the invoking session by default (#77).
+// Two sessions (s1, s2) both match the query. With the env var set to s1 and no
+// flag, the default drops s1 and keeps s2 — proving the binary reads the env var
+// and threads it into SearchOptions.current, the glue the in-process resolve unit
+// test cannot reach. The baseline (env cleared by the helper) lists both, so the
+// assertion cannot pass vacuously by returning nothing.
+#[test]
+fn search_excludes_current_session_by_env_default() {
+    let dir = TempDir::new().unwrap();
+    seed_two_matching_sessions(dir.path());
+
+    // Baseline: no invoking session (helper clears the env) → both are candidates.
+    let baseline = recall(dir.path())
+        .args(["search", "hello", "--no-embed"])
+        .output()
+        .expect("spawn recall binary");
+    let baseline_out = String::from_utf8_lossy(&baseline.stdout);
+    assert!(
+        baseline_out.contains("ID: s1") && baseline_out.contains("ID: s2"),
+        "baseline (no env) should list both sessions, got: {baseline_out}"
+    );
+
+    // CLAUDE_CODE_SESSION_ID=s1 → s1 is the invoking session, excluded by default.
+    let out = recall(dir.path())
+        .args(["search", "hello", "--no-embed"])
+        .env("CLAUDE_CODE_SESSION_ID", "s1")
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "search should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("ID: s2"),
+        "the non-current session must remain, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("ID: s1"),
+        "the invoking session (s1) must be excluded by default, got: {stdout}"
+    );
+}
+
+// T-CLI022: --include-current overrides the default exclusion (#77). With
+// CLAUDE_CODE_SESSION_ID=s1 the flag keeps s1, so both s1 and s2 appear — the
+// end-to-end path for the Ignore mode that the default/exclude tests never reach.
+#[test]
+fn search_include_current_keeps_invoking_session() {
+    let dir = TempDir::new().unwrap();
+    seed_two_matching_sessions(dir.path());
+
+    let out = recall(dir.path())
+        .args(["search", "hello", "--no-embed", "--include-current"])
+        .env("CLAUDE_CODE_SESSION_ID", "s1")
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "search should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("ID: s1") && stdout.contains("ID: s2"),
+        "--include-current must keep the invoking session, got: {stdout}"
+    );
+}
+
+// T-CLI023: --only-current restricts results to the invoking session (#77). With
+// CLAUDE_CODE_SESSION_ID=s1, only s1 appears even though s2 also matches — the
+// positive end-to-end path that T-CLI021 (the env-absent usage error) omits.
+#[test]
+fn search_only_current_restricts_to_invoking_session() {
+    let dir = TempDir::new().unwrap();
+    seed_two_matching_sessions(dir.path());
+
+    let out = recall(dir.path())
+        .args(["search", "hello", "--no-embed", "--only-current"])
+        .env("CLAUDE_CODE_SESSION_ID", "s1")
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "search should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("ID: s1"),
+        "--only-current must keep the invoking session, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("ID: s2"),
+        "--only-current must drop other sessions, got: {stdout}"
+    );
+}
+
+// T-CLI021: --only-current without CLAUDE_CODE_SESSION_ID is a usage error (64).
+// resolve_current_session has nothing to filter to, so it returns
+// RecallError::Usage; this pins that it classifies to the sysexits USAGE code end
+// to end (not a crash or a silently empty result). resolve runs before the DB is
+// opened, so no index is needed.
+#[test]
+fn only_current_without_env_exits_usage() {
+    let dir = TempDir::new().unwrap();
+    assert_eq!(
+        exit_code(recall(dir.path()).args(["search", "hello", "--no-embed", "--only-current"])),
+        64
     );
 }


### PR DESCRIPTION
## What & Why

`recall search` を Claude Code セッション内から実行すると、結果に自分自身の進行中セッションが混ざり自己参照になっていた。CLAUDE_CODE_SESSION_ID（Bash subprocess に渡る値。transcript ファイル名 stem = recall の session_id と一致）で呼び出し元セッションを識別し、デフォルトで除外する。

## Changes

- `search` に排他3フラグ `--exclude-current` / `--include-current` / `--only-current` を追加（clap `conflicts_with_all`、競合時 exit 64）
- env 検出時はフラグ無指定でも現セッションを除外（デフォルト）。env 未設定時は全件含む（既存挙動）
- 空/空白の CLAUDE_CODE_SESSION_ID は「未設定」扱い（`--only-current` は無言ゼロ結果ではなく usage error に）
- env→mode ポリシーを純粋関数 `resolve_current_session(flags, env)` に集約。env 読み取りは呼び出し元のみで、truth table を env 非依存でテスト可能
- `append_current_session_filter` を FTS・vec の両候補クエリに無条件適用。RRF merge が両集合を再 union するため、片経路フィルタだと漏れる
- ライブラリ `SearchOptions` の default は `Ignore` 維持で既存検索挙動は不変

## Scope

- Not included: 結果表示の `[current]` マーカー（YAGNI）、#92（vec チャンクレベル LIMIT）、#73（SessionEnd hook 連携）
- auto-index 廃止（#100）により検索時点で現セッションは未 index が通常。デフォルト除外が効くのは現セッションが index 済みの場合が主で、#73 の前提配線の性格が強い

## Design Decisions

- bool 3個ではなく `CurrentSessionFlags` 構造体 + enum `CurrentSession`（bool 引数の羅列回避、Rust 慣習）
- env ポリシーをライブラリ default ではなく CLI 層に限定し、既存 search.rs テストの挙動を不変に保つ
- post-filter ではなく候補生成段で除外し、既存の project/days/source フィルタと同じ単一 SQL 戦略に整合
- 両経路フィルタの回帰テストは除外対象を FTS・vec 両方にシード（どちらの経路の呼び忘れも検出。vec-only シードより上位互換）

## How to Test

1. 2セッション (s1, s2) を含む index で `CLAUDE_CODE_SESSION_ID=s1 recall search <q>` → s2 のみ（s1 除外）
2. env 未設定で同検索 → s1, s2 両方表示
3. `recall search <q> --only-current`（env 未設定）→ exit 64
4. `cargo test`（unit 160 + integration 23）/ `cargo clippy --all-targets -- -D warnings` / diff-cover gate 充足（99%、残1行は `unreachable!()` ガード）

## Related

- Closes #77
- 前提配線: #73 (SessionEnd hook)
