### PR TITLE
検索クエリの中間 &dyn ToSql Vec を params_from_iter で排除

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -146,9 +146,8 @@ fn find_candidate_sessions(
     now_ms: i64,
 ) -> Result<Vec<(String, f64)>> {
     let (sql, params) = build_fts_candidate_query(fts_query, opts, now_ms);
-    let refs: Vec<&dyn ToSql> = params.iter().map(AsRef::as_ref).collect();
     debug_assert_eq!(
-        refs.len(),
+        params.len(),
         sql.matches('?').count(),
         "param count must match SQL placeholder count"
     );
@@ -156,7 +155,7 @@ fn find_candidate_sessions(
         .prepare(&sql)
         .context("Failed to prepare search query")?;
     let rows = stmt
-        .query_map(refs.as_slice(), |row| {
+        .query_map(rusqlite::params_from_iter(params.iter()), |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
         })
         .context("Search query failed")?;
@@ -196,10 +195,9 @@ fn fetch_session_metadata(
         "SELECT session_id, source, file_path, project, slug, timestamp \
          FROM sessions WHERE session_id IN ({placeholders})"
     );
-    let refs: Vec<&dyn ToSql> = ranked.iter().map(|(sid, _)| sid as &dyn ToSql).collect();
-
+    let params = rusqlite::params_from_iter(ranked.iter().map(|(sid, _)| sid));
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(refs.as_slice(), |row| {
+    let rows = stmt.query_map(params, |row| {
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,


### PR DESCRIPTION
## What & Why

`find_candidate_sessions` と `fetch_session_metadata` は、検索クエリごとに `Vec<&dyn ToSql>` を再構築して `query_map` の slice 引数に渡していた。`rusqlite::params_from_iter(...)` で直接渡すことで、中間 Vec の alloc をクエリあたり 1 つ削減する（PR #48 /polish の EFF-002 を別出ししたもの）。

## Changes

- `find_candidate_sessions`: `params.iter().map(AsRef::as_ref).collect()` を排除し `params_from_iter(params.iter())` を直接 `query_map` へ。placeholder 数の `debug_assert` は `params.len()` に書き換え。
- `fetch_session_metadata`: 同様に `params_from_iter(ranked.iter().map(|(sid, _)| sid))` へ置換。

## Scope

- Not included（意図的）: `vec_search`。params が借用ローカル（`embedding_bytes` / `limit_i64`）と boxed filter params の混在で、`params_from_iter` 化は chain イテレータで可読性が下がり、`embedding_bytes` の再 Box で逆に alloc が増えうる。既存の `Vec::with_capacity` のままが最小かつ明快なので据え置き。
- perf 影響は実質ゼロ（検索は CLI 1 回/呼び出しで hot loop ではない）。コードクリーンアップ寄りの P2。

## How to Test

1. `cargo test`（unit 160 + integration 23）— 既存の検索テストが両クエリ経路（candidate / metadata）の回帰ガード
2. `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check`

挙動不変の refactor。amici のフィルタ helper（`Vec<Box<dyn ToSql>>` を取る）の signature は不変で、変更は search.rs 内に閉じる。

## Related

- Closes #49
- 契機: PR #48 /polish の EFF-002 finding（efficiency-reviewer）
