### PR TITLE
候補数の oversample 倍率 (limit*3) を共有 const に集約

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -21,6 +21,11 @@ use crate::date::MS_PER_DAY;
 use crate::hybrid::{self, RECENCY_BOOST_WEIGHT};
 use crate::parser::{SessionData, Source};
 
+/// Candidate over-sample factor: each path fetches `limit * CANDIDATE_LIMIT_MULTIPLIER`
+/// candidates before the RRF merge and recency boost truncate the union back to
+/// `limit`. Shared by the FTS and vec paths so the two stay in lockstep (#54).
+const CANDIDATE_LIMIT_MULTIPLIER: usize = 3;
+
 pub struct SearchResult {
     pub session: SessionData,
     /// Snippet with `**` highlight markers from FTS5.
@@ -134,7 +139,7 @@ fn build_fts_candidate_query(
     append_session_filter(&mut sql, &mut params, "session_id", opts, now_ms);
     append_current_session_filter(&mut sql, &mut params, "session_id", &opts.current);
     sql.push_str(" GROUP BY session_id ORDER BY best_rank LIMIT ?");
-    let candidate_limit = opts.limit * 3;
+    let candidate_limit = opts.limit * CANDIDATE_LIMIT_MULTIPLIER;
     params.push(Box::new(candidate_limit as i64));
     (sql, params)
 }
@@ -457,7 +462,7 @@ pub fn search_with_embedder(
     if let Some(embedder) = embedder
         && has_vec_data(conn)
     {
-        let candidate_limit = opts.limit * 3;
+        let candidate_limit = opts.limit * CANDIDATE_LIMIT_MULTIPLIER;
 
         let fts_hits: Vec<(String, f64)> = fts_ranked
             .iter()
@@ -821,7 +826,7 @@ mod tests {
         let (_dir, conn) = setup_test_db();
         let now_ms = 1_750_000_000_000_i64;
         let limit = 5;
-        let candidate_limit = limit * 3; // 15
+        let candidate_limit = limit * CANDIDATE_LIMIT_MULTIPLIER; // 15
 
         // Insert 20 old sessions (exceeds candidate_limit)
         for i in 0..20 {


### PR DESCRIPTION
## What & Why

FTS 候補クエリと vec 検索呼び出しがそれぞれ独立に `opts.limit * 3` を計算しており、oversample 倍率を変えると 2 経路が silently desync する（テストも `* 3` を 3 箇所目として再導出していた）。共有 const に集約し、倍率変更が FTS / vec / テストで自動連動するようにする。

## Changes

- `CANDIDATE_LIMIT_MULTIPLIER: usize = 3`（doc つき）を新設。
- `build_fts_candidate_query` / `search_with_embedder`（vec 経路）/ recency-boost テストの 3 箇所の `* 3` を const 参照に置換。

## Scope

- 挙動不変（倍率は 3 のまま）。値の変更ではなく単一ソース化のみ。
- この `3` は「RRF マージ前に limit の何倍の候補を集めるか」という同一知識から来ており、FTS と vec で意図的に別値を使う記録（ADR / コメント）はないため const 化が妥当。

## How to Test

1. `cargo test`（unit 160 + integration 23）— candidate プールが limit を超える状況を検証する recency-boost テストが回帰ガード。
2. `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` / diff-cover 100%（local 実測済み）。

挙動不変の refactor。

## Related

- Closes #54
