### PR TITLE
feat(search): FTSヒット抜粋を qa_chunk 全体に拡張

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,8 +129,6 @@ enum ModelCommand {
     Download,
 }
 
-const EXCERPT_MAX_BYTES: usize = 200;
-
 fn create_db_file(path: &Path) -> io::Result<()> {
     let mut opts = OpenOptions::new();
     opts.write(true).create_new(true);
@@ -150,10 +148,6 @@ fn format_timestamp(ts_ms: Option<i64>) -> String {
     let days = ts.div_euclid(date::MS_PER_DAY);
     let (y, m, d) = date::civil_from_days(days);
     format!("{y:04}-{m:02}-{d:02}")
-}
-
-fn truncate_str(s: &str, max_bytes: usize) -> &str {
-    &s[..s.floor_char_boundary(max_bytes)]
 }
 
 fn open_or_create_db(path: &Path) -> Result<Connection> {
@@ -663,13 +657,9 @@ fn format_result(w: &mut impl Write, i: usize, r: &search::SearchResult) -> io::
         writeln!(w, "    Parent: {parent}")?;
     }
     if !r.excerpt.is_empty() {
-        let clean = r.excerpt.trim();
-        let truncated = truncate_str(clean, EXCERPT_MAX_BYTES);
-        for line in truncated.lines() {
+        let excerpt = ansi::strip_control_chars(&r.excerpt);
+        for line in excerpt.trim().lines() {
             writeln!(w, "    > {line}")?;
-        }
-        if truncated.len() < clean.len() {
-            writeln!(w, "    > ...")?;
         }
     }
     writeln!(w)?;
@@ -906,25 +896,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_truncate_str() {
-        for (input, max, expected) in [
-            ("hello", 10, "hello"),
-            ("hello", 5, "hello"),
-            ("hello world", 5, "hello"),
-        ] {
-            assert_eq!(
-                truncate_str(input, max),
-                expected,
-                "input: {input:?}, max: {max}"
-            );
-        }
-        // Multibyte: 3 bytes per char, 10 bytes fits 3 chars (9 bytes)
-        let result = truncate_str("こんにちは", 10);
-        assert_eq!(result, "こんに");
-        assert!(result.len() <= 10);
-    }
-
     fn make_search_result(session_id: &str, project: &str, excerpt: &str) -> search::SearchResult {
         search::SearchResult {
             session: parser::SessionData {
@@ -981,14 +952,43 @@ mod tests {
         assert!(!output.contains("    /"));
     }
 
+    // T-004 (#8/FR-004): the excerpt renders in full — no byte-cap truncation and
+    // no "..." marker — so the whole chunk reaches the agent in one search.
     #[test]
-    fn test_format_result_truncated_excerpt() {
+    fn test_format_result_excerpt_not_truncated() {
         let long = "a".repeat(300);
         let r = make_search_result("s1", "/proj", &long);
         let mut buf = Vec::new();
         format_result(&mut buf, 0, &r).unwrap();
         let output = String::from_utf8(buf).unwrap();
-        assert!(output.contains("..."));
+        assert!(
+            output.contains(&format!("> {long}")),
+            "the full excerpt must render without truncation"
+        );
+        assert!(
+            !output.contains("> ..."),
+            "no truncation marker should be emitted, got: {output}"
+        );
+    }
+
+    // T-005 (#8 audit/C): the excerpt passes through ansi::strip_control_chars like
+    // every peer field (slug/project/session_id/file_path), so stored ANSI/control
+    // sequences from indexed content cannot reach the terminal raw. #8 expanded this
+    // surface (200-byte snippet -> full chunk content), making the gap material.
+    #[test]
+    fn test_format_result_excerpt_strips_control_chars() {
+        let r = make_search_result("s1", "/proj", "clean\x1b[31mANSI\x1b[0mhere\x07bell");
+        let mut buf = Vec::new();
+        format_result(&mut buf, 0, &r).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            !output.contains('\x1b') && !output.contains('\x07'),
+            "control characters must be stripped from the excerpt, got: {output:?}"
+        );
+        assert!(
+            output.contains("> cleanANSIherebell"),
+            "the cleaned excerpt text must render, got: {output:?}"
+        );
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -28,7 +28,9 @@ const CANDIDATE_LIMIT_MULTIPLIER: usize = 3;
 
 pub struct SearchResult {
     pub session: SessionData,
-    /// Snippet with `**` highlight markers from FTS5.
+    /// Excerpt for display: the full containing qa_chunk for an FTS hit, else the
+    /// FTS5 20-token snippet (with `**` highlight markers), else the closest vector
+    /// chunk, else empty.
     pub excerpt: String,
 }
 
@@ -305,30 +307,49 @@ fn snippet_or_default(result: rusqlite::Result<String>, session_id: &str) -> Opt
     }
 }
 
-fn fetch_snippets(
+fn fetch_chunks(
     conn: &Connection,
     fts_query: &str,
     ranked: Vec<(String, f64)>,
     meta_map: &mut HashMap<String, SessionData>,
     vec_chunks: &HashMap<String, i64>,
 ) -> Result<Vec<(f64, SearchResult)>> {
+    // Full chunk for an FTS hit (#8): find the message that matched, then the
+    // qa_chunk whose content contains that message text. `instr` runs on the
+    // already-matched message text (not the raw query), so FTS5 operators
+    // (AND/OR/quotes) are resolved by MATCH and never reach `instr`. Scoped to the
+    // session, so it scans only that session's handful of chunks (idx_qa_chunks_session).
+    // `ORDER BY rank` picks the most relevant matched message when several match,
+    // instead of an arbitrary rowid-ordered one.
+    let chunk_match_sql = "SELECT c.content FROM qa_chunks c \
+        JOIN (SELECT text FROM messages WHERE messages MATCH ?1 AND session_id = ?2 ORDER BY rank LIMIT 1) m \
+          ON instr(c.content, m.text) > 0 \
+        WHERE c.session_id = ?2 LIMIT 1";
+    let mut chunk_match_stmt = conn.prepare(chunk_match_sql)?;
+    // Fallback when no single chunk contains the matched message (e.g. the message
+    // was split across chunks, or the session has no qa_chunks): the 20-token snippet.
     let snippet_sql = "SELECT snippet(messages, 2, '**', '**', '...', 20) \
                FROM messages WHERE messages MATCH ?1 AND session_id = ?2 LIMIT 1";
     let mut snippet_stmt = conn.prepare(snippet_sql)?;
-    let chunk_sql = "SELECT content FROM qa_chunks WHERE id = ?1";
-    let mut chunk_stmt = conn.prepare(chunk_sql)?;
+    // Vector-only hit: no FTS match exists, so use the closest chunk by id (#36).
+    let vec_chunk_sql = "SELECT content FROM qa_chunks WHERE id = ?1";
+    let mut vec_chunk_stmt = conn.prepare(vec_chunk_sql)?;
     Ok(build_candidates(ranked, meta_map, |sid| {
+        if let Some(content) = snippet_or_default(
+            chunk_match_stmt.query_row(rusqlite::params![fts_query, sid], |row| row.get(0)),
+            sid,
+        ) {
+            return content;
+        }
         if let Some(snippet) = snippet_or_default(
             snippet_stmt.query_row(rusqlite::params![fts_query, sid], |row| row.get(0)),
             sid,
         ) {
             return snippet;
         }
-        // Vector-only hit: no FTS snippet exists. Fall back to the matched chunk's
-        // content so the result shows why it matched (#36).
         if let Some(&chunk_id) = vec_chunks.get(sid)
             && let Some(content) = snippet_or_default(
-                chunk_stmt.query_row(rusqlite::params![chunk_id], |row| row.get(0)),
+                vec_chunk_stmt.query_row(rusqlite::params![chunk_id], |row| row.get(0)),
                 sid,
             )
         {
@@ -477,7 +498,7 @@ pub fn search_with_embedder(
             }
         };
 
-        // Map each vector-hit session to its closest chunk so fetch_snippets can use
+        // Map each vector-hit session to its closest chunk so fetch_chunks can use
         // that chunk's content as the excerpt when there is no FTS snippet (#36).
         let vec_chunks: HashMap<String, i64> = vec_hits.iter().cloned().collect();
         let vec_for_rrf: Vec<(String, f64)> =
@@ -493,7 +514,7 @@ pub fn search_with_embedder(
 
         // Drop hits whose `sessions` row is missing or has an unknown source;
         // `fetch_session_metadata` skips those, and without pruning here they
-        // would consume `limit` slots during truncate and cause `fetch_snippets`
+        // would consume `limit` slots during truncate and cause `fetch_chunks`
         // to under-fill the result set.
         merged.retain(|(sid, _)| meta_map.contains_key(sid));
 
@@ -509,7 +530,7 @@ pub fn search_with_embedder(
         );
         merged.truncate(opts.limit);
 
-        let candidates = fetch_snippets(conn, &fts_query, merged, &mut meta_map, &vec_chunks)?;
+        let candidates = fetch_chunks(conn, &fts_query, merged, &mut meta_map, &vec_chunks)?;
         Ok(candidates.into_iter().map(|(_, r)| r).collect())
     } else {
         if fts_ranked.is_empty() {
@@ -519,7 +540,7 @@ pub fn search_with_embedder(
         // FTS-only path: every session matched FTS, so there is always a snippet;
         // pass an empty vec-chunk map (no vector-only fallback needed here).
         let candidates =
-            fetch_snippets(conn, &fts_query, fts_ranked, &mut meta_map, &HashMap::new())?;
+            fetch_chunks(conn, &fts_query, fts_ranked, &mut meta_map, &HashMap::new())?;
         Ok(score_and_sort(candidates, now_ms, opts.limit))
     }
 }
@@ -595,6 +616,131 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].session.session_id, "s1");
         assert!(!results[0].excerpt.is_empty());
+    }
+
+    // T-001 (#8): an FTS-hit excerpt is the full qa_chunk content, not a 20-token
+    // snippet of the matched message. The chunk holds the matched message text
+    // plus the rest of the Q&A; fetch_chunks locates it via instr(content,
+    // message_text) and returns the whole chunk.
+    #[test]
+    fn test_fts_hit_excerpt_is_full_chunk_not_snippet() {
+        let (_dir, conn) = setup_test_db();
+        insert_session(&conn, "s1", "claude", "/proj", 1709251200000);
+        insert_message(&conn, "s1", "user", "how to implement authentication");
+        insert_chunk_with_embedding(
+            &conn,
+            1,
+            "s1",
+            "how to implement authentication — use JWT with short-lived access tokens and rotating refresh tokens",
+            1709251200000,
+        );
+
+        let results = search(&conn, "authentication", &SearchOptions::default()).unwrap();
+
+        assert_eq!(results.len(), 1);
+        let excerpt = &results[0].excerpt;
+        assert!(
+            excerpt.contains("rotating refresh tokens"),
+            "FTS-hit excerpt must be the full chunk, not a 20-token snippet: {excerpt:?}"
+        );
+    }
+
+    // T-002 (#8): a multi-term (implicit-AND) query still resolves to the
+    // containing chunk. MATCH applies the operator; instr only sees the concrete
+    // matched message text, so the operator never reaches instr.
+    #[test]
+    fn test_fts_operator_query_returns_containing_chunk() {
+        let (_dir, conn) = setup_test_db();
+        insert_session(&conn, "s1", "claude", "/proj", 1709251200000);
+        insert_message(
+            &conn,
+            "s1",
+            "user",
+            "authentication middleware configuration",
+        );
+        insert_chunk_with_embedding(
+            &conn,
+            1,
+            "s1",
+            "authentication middleware configuration — mount it before the route handlers",
+            1709251200000,
+        );
+
+        let results = search(
+            &conn,
+            "authentication middleware",
+            &SearchOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 1);
+        let excerpt = &results[0].excerpt;
+        assert!(
+            excerpt.contains("mount it before the route handlers"),
+            "operator query must return the full containing chunk: {excerpt:?}"
+        );
+    }
+
+    // T-003 (#8): an FTS hit whose session has no containing qa_chunk falls back to
+    // the 20-token snippet (with `**` highlight markers), not an empty excerpt.
+    #[test]
+    fn test_fts_hit_without_chunk_falls_back_to_snippet() {
+        let (_dir, conn) = setup_test_db();
+        insert_session(&conn, "s1", "claude", "/proj", 1709251200000);
+        insert_message(&conn, "s1", "user", "authentication flow discussion");
+        // no qa_chunk inserted for s1
+
+        let results = search(&conn, "authentication", &SearchOptions::default()).unwrap();
+
+        assert_eq!(results.len(), 1);
+        let excerpt = &results[0].excerpt;
+        assert!(
+            excerpt.contains("**"),
+            "fallback must be the FTS snippet (** markers), not a chunk: {excerpt:?}"
+        );
+    }
+
+    // T-006 (#8 audit/B): when a session has multiple messages matching the query,
+    // the chunk of the highest-ranked (most relevant) message is selected, not an
+    // arbitrary rowid-ordered one. `chunk_match_sql` orders the inner message
+    // subquery by FTS5 `rank`. The low-rank message is inserted first (lower rowid),
+    // so a rowid-ordered LIMIT 1 would pick the wrong chunk.
+    #[test]
+    fn test_fts_hit_selects_highest_ranked_message_chunk() {
+        let (_dir, conn) = setup_test_db();
+        insert_session(&conn, "s1", "claude", "/proj", 1709251200000);
+        // rowid 1: long, diluted -> lower bm25 rank for "authentication".
+        insert_message(
+            &conn,
+            "s1",
+            "user",
+            "authentication alpha padded with many extra filler words here to lower its relevance",
+        );
+        // rowid 2: short, focused -> higher bm25 rank.
+        insert_message(&conn, "s1", "user", "authentication beta");
+        insert_chunk_with_embedding(
+            &conn,
+            1,
+            "s1",
+            "authentication alpha padded with many extra filler words here to lower its relevance — ALPHA_CHUNK_BODY",
+            1709251200000,
+        );
+        insert_chunk_with_embedding(
+            &conn,
+            2,
+            "s1",
+            "authentication beta — BETA_CHUNK_BODY",
+            1709251200000,
+        );
+
+        let results = search(&conn, "authentication", &SearchOptions::default()).unwrap();
+
+        assert_eq!(results.len(), 1);
+        let excerpt = &results[0].excerpt;
+        assert!(
+            excerpt.contains("BETA_CHUNK_BODY"),
+            "must select the highest-ranked message's chunk, not the first by rowid: {excerpt:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`recall search` はキーワードヒットに対し 20 トークンの FTS スニペットしか表示せず、周辺の Q&A を読むには `show` の追い打ちが必要だった。FTS ヒット時はマッチした message を含む qa_chunk 全体を返すようにし、エージェントが 1 回の検索で文脈を得られるようにする。

## 実装

- `fetch_snippets` → `fetch_chunks`: マッチした message を特定し（`messages MATCH`）、その message text を含む qa_chunk を `instr(content, message_text)` で探す。`instr` は生クエリではなくマッチ済み message text に対して走るため、FTS5 演算子（AND/OR/引用符）は MATCH で解決され `instr` に届かない。
- フォールバック連鎖: 含有 chunk → 20 トークン snippet（message 分割 / chunk 無し）→ ベクトル最近傍 chunk（vec のみヒット）→ 空。
- `format_result` の `EXCERPT_MAX_BYTES` 切り詰めを廃止し chunk 全体を表示（FR-004）。未使用の `truncate_str` を削除。

## 監査による堅牢化（マージ前のセルフレビュー）

差分に対し `/audit`（10 reviewer → challenge → verify → root-cause）を実施。確定した指摘を本 PR で修正:

- 制御文字の sanitize: excerpt を `format_result` で `ansi::strip_control_chars` に通し、他の全フィールドと整合させた。chunk 全体の内容は、従来の 200 バイト snippet が覆い隠していた未信頼の出力面であり、内容ソースの変更で顕在化した既存ギャップ。`result_to_json` は意図的に raw のまま: JSON は全フィールド raw かつ serde が制御文字をエスケープするため、excerpt だけ sanitize すると新たな非対称を生む。
- 決定的な chunk 選択: マッチ message の subquery に `ORDER BY rank` を付与。複数マッチ session で rowid 順の任意な chunk ではなく最も関連度の高い message の chunk を選ぶ。
- doc 修正: `SearchResult.excerpt` の doc を全フォールバックケース記載に更新。

降格 / 対象外: 出力無上限（単一 chunk は chunker が 16 KB で上限化するため、これは意図された FR-004 の挙動）。`instr` 連結（message→chunk の FK 不在）は二重 MATCH と短語ミスマッチ残存の構造的真因であり、follow-up として別途追跡。

## テスト

T-001 chunk 全体、T-002 演算子クエリ、T-003 snippet フォールバック、T-004 切り詰めなし、T-005 制御文字除去、T-006 rank 順 chunk。`cargo test` 164+23 緑、`clippy --all-targets -D warnings` clean、diff-cover 100%。

Closes #8
