### PR TITLE
feat(classify): セッション分類フィルタで automated を既定除外

### DIFF
--- a/src/classify.rs
+++ b/src/classify.rs
@@ -1,0 +1,107 @@
+//! Session classification (#24): label a session interactive or automated from
+//! its first user turn, so `recall search` can exclude hook/script-generated
+//! noise by default. Markers are programmatic prefixes intrinsic to the
+//! Claude/Codex ecosystem (slash-command wrappers, local-command I/O, synthetic
+//! actions, interrupt/continuation strings). A false positive would hide a real
+//! session from default search, so only prefixes a human is very unlikely to open
+//! a session with belong here. Matched literally — no regex/config dependency.
+
+/// Classification of a session, derived from its first user turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionType {
+    /// Human-driven session. The default whenever no marker matches.
+    Interactive,
+    /// Hook / script / slash-command / agent-generated session.
+    Automated,
+}
+
+impl SessionType {
+    /// The value stored in `sessions.session_type`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SessionType::Interactive => "interactive",
+            SessionType::Automated => "automated",
+        }
+    }
+}
+
+/// Programmatic prefixes that mark a session as automated. Each is a string
+/// tooling injects verbatim at the start of a turn but a human is very unlikely
+/// to open a session with: slash-command wrappers, synthetic actions, local-command
+/// I/O, the interrupt notice, and the compaction-continuation opener. Verified
+/// against ~/.recall.db (5899 sessions). Keep entries unambiguous — a false match
+/// hides a real session from default search.
+const AUTOMATED_MARKERS: &[&str] = &[
+    "<command-message>",
+    "<user_action>",
+    "<local-command-stdout>",
+    "<local-command-caveat>",
+    "<bash-input>",
+    "[Request interrupted by user",
+    "This session is being continued",
+];
+
+/// Classify a session from its first user turn. Leading whitespace is trimmed
+/// (tooling often injects a newline + indent before the marker), then the turn is
+/// matched against [`AUTOMATED_MARKERS`] at its start. Anchoring at the start means
+/// a marker appearing mid-sentence in a genuine human turn does not trip the match,
+/// and the scan is inherently bounded to the marker lengths (well within the first
+/// 120 characters). Returns [`SessionType::Interactive`] when nothing matches —
+/// including an empty or whitespace-only turn — so an unmatched session is never
+/// hidden by default.
+pub fn classify_first_turn(first_turn: &str) -> SessionType {
+    let head = first_turn.trim_start();
+    if AUTOMATED_MARKERS
+        .iter()
+        .any(|marker| head.starts_with(marker))
+    {
+        SessionType::Automated
+    } else {
+        SessionType::Interactive
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-001 (#24/FR-001): XML-wrapper markers classify as automated, even with the
+    // leading newline + indent that tooling injects before the tag.
+    #[test]
+    fn test_xml_wrapper_with_leading_whitespace_is_automated() {
+        for turn in [
+            "\n            <command-message>clear</command-message>",
+            "<user_action>\n  <context>review</context>",
+            "<local-command-stdout>Goodbye!</local-command-stdout>",
+            "<bash-input>git push</bash-input>",
+        ] {
+            assert_eq!(
+                classify_first_turn(turn),
+                SessionType::Automated,
+                "turn: {turn:?}"
+            );
+        }
+    }
+
+    // T-002 (#24/FR-001): the compaction continuation opener classifies as automated.
+    #[test]
+    fn test_continuation_marker_is_automated() {
+        let turn =
+            "This session is being continued from a previous conversation that ran out of context.";
+        assert_eq!(classify_first_turn(turn), SessionType::Automated);
+    }
+
+    // T-003 (#24/FR-002, FR-010): a normal human turn and an empty/whitespace turn
+    // (a session with no user turn) both classify as interactive, so they are never
+    // hidden from default search.
+    #[test]
+    fn test_human_and_empty_turn_is_interactive() {
+        for turn in ["how do I implement authentication?", "", "   \n  "] {
+            assert_eq!(
+                classify_first_turn(turn),
+                SessionType::Interactive,
+                "turn: {turn:?}"
+            );
+        }
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -28,13 +28,15 @@ fn create_schema(conn: &mut Connection) -> Result<()> {
             project TEXT,
             slug TEXT,
             timestamp INTEGER,
-            mtime REAL
+            mtime REAL,
+            session_type TEXT
         );",
     )?;
 
     migrate_fts_if_needed(conn)?;
     migrate_vec_chunks_if_needed(conn)?;
     migrate_qa_chunks_if_needed(conn)?;
+    migrate_session_type_if_needed(conn)?;
 
     // embedded_chunk_ids (a removed ledger) was dropped inside two separate
     // migrations; collapse those into one unconditional drop so every pre-cleanup
@@ -133,6 +135,24 @@ fn migrate_qa_chunks_if_needed(conn: &mut Connection) -> Result<()> {
     Ok(())
 }
 
+/// Add session_type to pre-classification databases. ALTER ... ADD COLUMN keeps
+/// every existing row (the new column is NULL, treated as interactive by the
+/// search filter), so no re-index is forced — retroactive tagging is the explicit
+/// `recall classify` command's job (#24).
+fn migrate_session_type_if_needed(conn: &mut Connection) -> Result<()> {
+    let Some(sql) = table_def(conn, "sessions")? else {
+        return Ok(());
+    };
+
+    if !sql.contains("session_type") {
+        let tx = conn.transaction()?;
+        tx.execute_batch("ALTER TABLE sessions ADD COLUMN session_type TEXT;")?;
+        tx.commit()?;
+    }
+
+    Ok(())
+}
+
 fn migrate_fts_if_needed(conn: &mut Connection) -> Result<()> {
     let Some(sql) = table_def(conn, "messages")? else {
         return Ok(());
@@ -203,6 +223,53 @@ mod tests {
         let tmp = NamedTempFile::new().unwrap();
         let _conn1 = open_db(tmp.path()).unwrap();
         let _conn2 = open_db(tmp.path()).unwrap();
+    }
+
+    // T-009 (#24/FR-004): opening a DB whose sessions table predates session_type
+    // adds the column non-destructively — existing rows survive with NULL (treated
+    // as interactive by the search filter), not a destructive rebuild.
+    #[test]
+    fn test_session_type_migration_adds_column_preserving_rows() {
+        let tmp = NamedTempFile::new().unwrap();
+        // Pre-session_type schema: 7-column sessions + a trigram messages table, so
+        // the FTS migration does not fire and wipe sessions.
+        {
+            let conn = Connection::open(tmp.path()).unwrap();
+            conn.execute_batch(&format!(
+                "CREATE TABLE sessions (
+                    session_id TEXT PRIMARY KEY, source TEXT, file_path TEXT,
+                    project TEXT, slug TEXT, timestamp INTEGER, mtime REAL
+                );
+                CREATE VIRTUAL TABLE messages USING fts5(
+                    session_id UNINDEXED, role, text, tokenize='{FTS_TOKENIZER}'
+                );"
+            ))
+            .unwrap();
+            conn.execute(
+                "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0)",
+                [],
+            )
+            .unwrap();
+        }
+
+        let conn = open_db(tmp.path()).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "existing session row must survive the migration");
+
+        let session_type: Option<String> = conn
+            .query_row(
+                "SELECT session_type FROM sessions WHERE session_id = 's1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            session_type, None,
+            "pre-existing rows get NULL session_type"
+        );
     }
 
     /// Create a DB with a pre-trigram tokenizer and one session+message.

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -241,7 +241,7 @@ mod tests {
     fn test_embed_chunks_progress_callback() {
         let (_dir, mut conn) = setup_test_db();
         conn.execute(
-            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0)",
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
             [],
         )
         .unwrap();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -10,6 +10,7 @@ use rusqlite::{Connection, Transaction};
 use tracing::{debug, info, warn};
 
 use crate::chunker;
+use crate::classify::classify_first_turn;
 use crate::parser::{
     Message, ParseResult, Role, Source, parse_claude_session, parse_codex_session,
 };
@@ -117,8 +118,21 @@ fn upsert_session(
         )?;
     }
 
+    // Classify from the first user turn so `recall search` can exclude automated
+    // sessions by default (#24). Done at ingest from the already-parsed messages —
+    // no extra read. No user turn → interactive (never hidden by default).
+    let session_type = classify_first_turn(
+        parsed
+            .messages
+            .iter()
+            .find(|m| matches!(m.role, Role::User))
+            .map(|m| m.text.as_str())
+            .unwrap_or(""),
+    )
+    .as_str();
+
     ctx.tx.execute(
-        "INSERT OR REPLACE INTO sessions (session_id, source, file_path, project, slug, timestamp, mtime) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        "INSERT OR REPLACE INTO sessions (session_id, source, file_path, project, slug, timestamp, mtime, session_type) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         rusqlite::params![
             parsed.metadata.session_id,
             parsed.metadata.source.as_str(),
@@ -127,6 +141,7 @@ fn upsert_session(
             parsed.metadata.slug,
             parsed.metadata.timestamp,
             mtime,
+            session_type,
         ],
     )?;
 
@@ -532,6 +547,45 @@ mod tests {
         .unwrap();
         assert_eq!(stats2.indexed, 0);
         assert_eq!(stats2.total_sessions, 1);
+    }
+
+    fn index_one_claude_session(content: &str) -> Option<String> {
+        let (_dir, mut conn) = setup_test_db();
+        let tmp = TempDir::new().unwrap();
+        let claude_dir = tmp.path().join("claude_projects");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let line = format!(
+            r#"{{"type":"user","cwd":"/proj","message":{{"role":"user","content":{content:?}}},"timestamp":"2026-03-01T00:00:00Z"}}"#
+        );
+        fs::write(claude_dir.join("s.jsonl"), line).unwrap();
+        let codex_dir = tmp.path().join("codex_sessions");
+        index_from_dirs(
+            &mut conn,
+            &IndexOptions {
+                force: false,
+                claude_dir: &claude_dir,
+                codex_dir: &codex_dir,
+            },
+        )
+        .unwrap();
+        conn.query_row("SELECT session_type FROM sessions", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    // T-004 (#24/FR-003): ingest tags session_type from the first user turn — an
+    // automated marker yields 'automated', a human turn yields 'interactive'.
+    #[test]
+    fn test_ingest_tags_session_type_from_first_user_turn() {
+        assert_eq!(
+            index_one_claude_session("<command-message>clear</command-message>").as_deref(),
+            Some("automated"),
+            "a slash-command first turn must be tagged automated"
+        );
+        assert_eq!(
+            index_one_claude_session("how do I implement authentication").as_deref(),
+            Some("interactive"),
+            "a human first turn must be tagged interactive"
+        );
     }
 
     #[test]
@@ -969,7 +1023,7 @@ mod tests {
         let (_dir, mut conn) = setup_test_db();
 
         conn.execute(
-            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0)",
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
             [],
         )
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod ansi;
 mod chunker;
+mod classify;
 mod date;
 mod db;
 mod embedder;
@@ -1072,12 +1073,12 @@ mod tests {
     fn setup_show_db() -> (tempfile::TempDir, Connection) {
         let (dir, conn) = db::setup_test_db();
         conn.execute(
-            "INSERT INTO sessions VALUES ('abc-123', 'claude', '/path/f.jsonl', '/proj', 'my-slug', 1709251200000, 0.0)",
+            "INSERT INTO sessions VALUES ('abc-123', 'claude', '/path/f.jsonl', '/proj', 'my-slug', 1709251200000, 0.0, NULL)",
             [],
         )
         .unwrap();
         conn.execute(
-            "INSERT INTO sessions VALUES ('abc-456', 'claude', '/path/g.jsonl', '/proj', 'other-slug', 1709251200000, 0.0)",
+            "INSERT INTO sessions VALUES ('abc-456', 'claude', '/path/g.jsonl', '/proj', 'other-slug', 1709251200000, 0.0, NULL)",
             [],
         )
         .unwrap();
@@ -1154,7 +1155,7 @@ mod tests {
     fn setup_pending_chunk_db() -> (tempfile::TempDir, Connection) {
         let (dir, conn) = db::setup_test_db();
         conn.execute(
-            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0)",
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
             [],
         )
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,11 @@ enum Command {
         /// Return only the invoking session (requires CLAUDE_CODE_SESSION_ID).
         #[arg(long, conflicts_with_all = ["exclude_current", "include_current"])]
         only_current: bool,
+
+        /// Include sessions classified automated (hook/script/agent-generated).
+        /// Default excludes them.
+        #[arg(long)]
+        include_automated: bool,
     },
     /// Show full conversation of a session
     Show {
@@ -366,6 +371,7 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<CommandOutput> 
         exclude_current,
         include_current,
         only_current,
+        include_automated,
     } = cmd
     else {
         unreachable!()
@@ -417,6 +423,7 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<CommandOutput> 
             source,
             limit: limit.into(),
             current,
+            include_automated,
             now_ms: None,
         },
         embedder.as_deref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,15 @@ enum Command {
         /// Session ID (prefix match supported)
         session_id: String,
     },
+    /// Classify existing sessions interactive/automated from their first user turn
+    Classify {
+        /// Re-classify every session (default: only unclassified)
+        #[arg(long)]
+        all: bool,
+        /// Report what would change without writing
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Show index and embedding status
     Status,
 }
@@ -744,10 +753,112 @@ fn emit_error(err: &anyhow::Error, json_mode: bool) {
     }
 }
 
+/// One session's reclassification result (#24 Phase 3).
+struct ClassifyOutcome {
+    session_id: String,
+    session_type: classify::SessionType,
+    /// First ~80 chars of the first user turn (after trim), for `--dry-run` display.
+    excerpt: String,
+}
+
+/// Re-classify existing sessions from their first user turn and update
+/// `session_type`. With `all`, every session that has a user turn is re-evaluated;
+/// otherwise only those still unclassified (NULL). When `dry_run`, nothing is
+/// written — the caller displays the returned outcomes. Sessions without a user
+/// turn are left untouched (NULL = interactive).
+fn reclassify_sessions(
+    conn: &Connection,
+    all: bool,
+    dry_run: bool,
+) -> Result<Vec<ClassifyOutcome>> {
+    // First user turn per session: the lowest-rowid user message (document order,
+    // AS-003). Without `all`, restrict to still-unclassified sessions.
+    let base = "SELECT m.session_id, m.text FROM messages m \
+        WHERE m.rowid IN (SELECT MIN(rowid) FROM messages WHERE role = 'user' GROUP BY session_id)";
+    let sql = if all {
+        base.to_owned()
+    } else {
+        format!(
+            "{base} AND m.session_id IN (SELECT session_id FROM sessions WHERE session_type IS NULL)"
+        )
+    };
+
+    let outcomes = {
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut outcomes = Vec::new();
+        for row in rows {
+            let (session_id, first_turn) = row?;
+            let session_type = classify::classify_first_turn(&first_turn);
+            let excerpt: String = first_turn.trim_start().chars().take(80).collect();
+            outcomes.push(ClassifyOutcome {
+                session_id,
+                session_type,
+                excerpt,
+            });
+        }
+        outcomes
+    };
+
+    if !dry_run {
+        let mut update =
+            conn.prepare("UPDATE sessions SET session_type = ?2 WHERE session_id = ?1")?;
+        for o in &outcomes {
+            update.execute(rusqlite::params![o.session_id, o.session_type.as_str()])?;
+        }
+    }
+
+    Ok(outcomes)
+}
+
+/// `recall classify`: tag existing sessions interactive/automated from their first
+/// user turn (#24 Phase 3). `--all` re-classifies every session; otherwise only
+/// unclassified ones. `--dry-run` reports what would change without writing.
+fn run_classify(all: bool, dry_run: bool, db_path: &Option<PathBuf>) -> Result<CommandOutput> {
+    let path = resolve_db_path(db_path)?;
+    let conn = open_or_create_db(&path)?;
+    let outcomes = reclassify_sessions(&conn, all, dry_run)?;
+    let automated = outcomes
+        .iter()
+        .filter(|o| o.session_type == classify::SessionType::Automated)
+        .count();
+    let interactive = outcomes.len() - automated;
+
+    let mut markdown = String::new();
+    if dry_run {
+        for o in &outcomes {
+            markdown.push_str(&format!(
+                "{} [{}] {}\n",
+                o.session_id,
+                o.session_type.as_str(),
+                o.excerpt
+            ));
+        }
+        markdown.push_str(&format!(
+            "dry-run: {} session(s) would be classified ({automated} automated, {interactive} interactive)",
+            outcomes.len()
+        ));
+    } else {
+        markdown.push_str(&format!(
+            "classified {} session(s): {automated} automated, {interactive} interactive",
+            outcomes.len()
+        ));
+    }
+    let data = serde_json::json!({
+        "classified": outcomes.len(),
+        "automated": automated,
+        "interactive": interactive,
+        "dry_run": dry_run,
+    });
+    Ok(CommandOutput::ok(markdown, data))
+}
+
 // -- Entry point --
 
 const KNOWN_SUBCOMMANDS: &[&str] = &[
-    "index", "rebuild", "embed", "model", "search", "show", "status", "help",
+    "index", "rebuild", "embed", "model", "search", "show", "status", "classify", "help",
 ];
 const GLOBAL_FLAGS: &[&str] = &["--verbose", "-v", "--json"];
 
@@ -798,6 +909,7 @@ fn run(cli: Cli) -> Result<CommandOutput> {
         Some(Command::Model(ModelCommand::Download)) => run_model_download().map(|()| no_payload()),
         Some(cmd @ Command::Search { .. }) => run_search(cmd, &cli.db_path),
         Some(Command::Show { session_id }) => run_show(&session_id, cli.verbose, &cli.db_path),
+        Some(Command::Classify { all, dry_run }) => run_classify(all, dry_run, &cli.db_path),
         Some(Command::Status) => run_status(cli.verbose, &cli.db_path),
         None => Err(RecallError::Usage(
             "A search query is required. Usage: recall search \"query\" or recall index".to_owned(),
@@ -1159,6 +1271,126 @@ mod tests {
 
     /// Seed one session with one pending (un-embedded) chunk, the fixture both
     /// `embed_around_results` tests share.
+    fn seed_classify_db() -> (tempfile::TempDir, Connection) {
+        let (dir, conn) = db::setup_test_db();
+        // 'auto': first user turn is a slash-command wrapper; 'human': a normal
+        // turn. Both start unclassified (session_type NULL).
+        conn.execute(
+            "INSERT INTO sessions VALUES ('auto', 'claude', '/f', '/p', 'a', 0, 0.0, NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, text) VALUES ('auto', 'user', '<command-message>clear</command-message>')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('human', 'claude', '/f', '/p', 'h', 0, 0.0, NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, text) VALUES ('human', 'user', 'how do I implement auth')",
+            [],
+        )
+        .unwrap();
+        (dir, conn)
+    }
+
+    fn session_type_of(conn: &Connection, sid: &str) -> Option<String> {
+        conn.query_row(
+            "SELECT session_type FROM sessions WHERE session_id = ?1",
+            [sid],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    // T-010 (#24/FR-008): `recall classify --all` re-classifies existing sessions
+    // from their first user turn and writes session_type.
+    #[test]
+    fn test_010_reclassify_all_tags_sessions() {
+        let (_dir, conn) = seed_classify_db();
+        let outcomes = reclassify_sessions(&conn, true, false).unwrap();
+        assert_eq!(session_type_of(&conn, "auto").as_deref(), Some("automated"));
+        assert_eq!(
+            session_type_of(&conn, "human").as_deref(),
+            Some("interactive")
+        );
+        assert_eq!(
+            outcomes.len(),
+            2,
+            "both sessions with a user turn are classified"
+        );
+    }
+
+    // T-011 (#24/FR-009a, FR-009b): --dry-run returns outcomes for display but does
+    // not write session_type.
+    #[test]
+    fn test_011_reclassify_dry_run_does_not_write() {
+        let (_dir, conn) = seed_classify_db();
+        let outcomes = reclassify_sessions(&conn, true, true).unwrap();
+        assert_eq!(
+            session_type_of(&conn, "auto"),
+            None,
+            "dry-run must not write session_type"
+        );
+        assert_eq!(session_type_of(&conn, "human"), None);
+        let auto = outcomes
+            .iter()
+            .find(|o| o.session_id == "auto")
+            .expect("dry-run still reports the outcome for display");
+        assert_eq!(auto.session_type, classify::SessionType::Automated);
+    }
+
+    // T-012 (#24/FR-008): without --all, only unclassified (NULL) sessions are
+    // (re)classified; an already-tagged session is left untouched.
+    #[test]
+    fn test_012_reclassify_incremental_skips_already_tagged() {
+        let (_dir, conn) = db::setup_test_db();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('fresh', 'claude', '/f', '/p', 'f', 0, 0.0, NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, text) VALUES ('fresh', 'user', '<command-message>clear</command-message>')",
+            [],
+        )
+        .unwrap();
+        // 'tagged' carries an automated first turn but was already tagged interactive;
+        // without --all it must stay interactive (not re-evaluated).
+        conn.execute(
+            "INSERT INTO sessions VALUES ('tagged', 'claude', '/f', '/p', 't', 0, 0.0, 'interactive')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, text) VALUES ('tagged', 'user', '<command-message>clear</command-message>')",
+            [],
+        )
+        .unwrap();
+
+        let outcomes = reclassify_sessions(&conn, false, false).unwrap();
+
+        assert_eq!(
+            session_type_of(&conn, "fresh").as_deref(),
+            Some("automated"),
+            "an unclassified session is classified"
+        );
+        assert_eq!(
+            session_type_of(&conn, "tagged").as_deref(),
+            Some("interactive"),
+            "an already-tagged session is untouched without --all"
+        );
+        assert_eq!(
+            outcomes.len(),
+            1,
+            "only the unclassified session is processed"
+        );
+    }
+
     fn setup_pending_chunk_db() -> (tempfile::TempDir, Connection) {
         let (dir, conn) = db::setup_test_db();
         conn.execute(

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<CommandOutput> 
     let embedder = try_load_embedder_cached();
     // A missing embedding model degrades search to FTS-only; surface it so an
     // agent knows semantic ranking was unavailable (the `--json` notes channel).
-    let (degraded, notes) = match &embedder {
+    let (degraded, mut notes) = match &embedder {
         Some(_) => (false, Vec::new()),
         None => (
             true,
@@ -437,6 +437,25 @@ fn run_search(cmd: Command, db_path: &Option<PathBuf>) -> Result<CommandOutput> 
         },
         embedder.as_deref(),
     )?;
+
+    // Surface the default automated-session exclusion so an agent consumer can
+    // discover --include-automated; skipped when the agent already opted in.
+    if !include_automated {
+        // Best-effort: a failed count skips the advisory note rather than aborting
+        // an otherwise-successful search.
+        let automated: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE session_type = 'automated'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        if automated > 0 {
+            notes.push(format!(
+                "{automated} automated session(s) excluded by default; use --include-automated to include them"
+            ));
+        }
+    }
 
     let markdown = render_results(&results);
     let data = serde_json::json!({
@@ -767,7 +786,7 @@ struct ClassifyOutcome {
 /// written — the caller displays the returned outcomes. Sessions without a user
 /// turn are left untouched (NULL = interactive).
 fn reclassify_sessions(
-    conn: &Connection,
+    conn: &mut Connection,
     all: bool,
     dry_run: bool,
 ) -> Result<Vec<ClassifyOutcome>> {
@@ -792,7 +811,13 @@ fn reclassify_sessions(
         for row in rows {
             let (session_id, first_turn) = row?;
             let session_type = classify::classify_first_turn(&first_turn);
-            let excerpt: String = first_turn.trim_start().chars().take(80).collect();
+            // The excerpt is for --dry-run display only; skip the allocation on the
+            // write path where it is never read.
+            let excerpt = if dry_run {
+                first_turn.trim_start().chars().take(80).collect()
+            } else {
+                String::new()
+            };
             outcomes.push(ClassifyOutcome {
                 session_id,
                 session_type,
@@ -803,11 +828,18 @@ fn reclassify_sessions(
     };
 
     if !dry_run {
-        let mut update =
-            conn.prepare("UPDATE sessions SET session_type = ?2 WHERE session_id = ?1")?;
-        for o in &outcomes {
-            update.execute(rusqlite::params![o.session_id, o.session_type.as_str()])?;
+        // One transaction for the whole batch: a single commit instead of one per
+        // row, and all-or-nothing so an interrupted run leaves session_type
+        // unchanged and is cleanly re-runnable.
+        let tx = conn.transaction()?;
+        {
+            let mut update =
+                tx.prepare("UPDATE sessions SET session_type = ?2 WHERE session_id = ?1")?;
+            for o in &outcomes {
+                update.execute(rusqlite::params![o.session_id, o.session_type.as_str()])?;
+            }
         }
+        tx.commit()?;
     }
 
     Ok(outcomes)
@@ -818,8 +850,8 @@ fn reclassify_sessions(
 /// unclassified ones. `--dry-run` reports what would change without writing.
 fn run_classify(all: bool, dry_run: bool, db_path: &Option<PathBuf>) -> Result<CommandOutput> {
     let path = resolve_db_path(db_path)?;
-    let conn = open_or_create_db(&path)?;
-    let outcomes = reclassify_sessions(&conn, all, dry_run)?;
+    let mut conn = open_or_create_db(&path)?;
+    let outcomes = reclassify_sessions(&mut conn, all, dry_run)?;
     let automated = outcomes
         .iter()
         .filter(|o| o.session_type == classify::SessionType::Automated)
@@ -1311,8 +1343,8 @@ mod tests {
     // from their first user turn and writes session_type.
     #[test]
     fn test_010_reclassify_all_tags_sessions() {
-        let (_dir, conn) = seed_classify_db();
-        let outcomes = reclassify_sessions(&conn, true, false).unwrap();
+        let (_dir, mut conn) = seed_classify_db();
+        let outcomes = reclassify_sessions(&mut conn, true, false).unwrap();
         assert_eq!(session_type_of(&conn, "auto").as_deref(), Some("automated"));
         assert_eq!(
             session_type_of(&conn, "human").as_deref(),
@@ -1329,8 +1361,8 @@ mod tests {
     // not write session_type.
     #[test]
     fn test_011_reclassify_dry_run_does_not_write() {
-        let (_dir, conn) = seed_classify_db();
-        let outcomes = reclassify_sessions(&conn, true, true).unwrap();
+        let (_dir, mut conn) = seed_classify_db();
+        let outcomes = reclassify_sessions(&mut conn, true, true).unwrap();
         assert_eq!(
             session_type_of(&conn, "auto"),
             None,
@@ -1342,13 +1374,17 @@ mod tests {
             .find(|o| o.session_id == "auto")
             .expect("dry-run still reports the outcome for display");
         assert_eq!(auto.session_type, classify::SessionType::Automated);
+        assert!(
+            !auto.excerpt.is_empty(),
+            "dry-run outcome carries the first-turn excerpt for display"
+        );
     }
 
     // T-012 (#24/FR-008): without --all, only unclassified (NULL) sessions are
     // (re)classified; an already-tagged session is left untouched.
     #[test]
     fn test_012_reclassify_incremental_skips_already_tagged() {
-        let (_dir, conn) = db::setup_test_db();
+        let (_dir, mut conn) = db::setup_test_db();
         conn.execute(
             "INSERT INTO sessions VALUES ('fresh', 'claude', '/f', '/p', 'f', 0, 0.0, NULL)",
             [],
@@ -1372,7 +1408,7 @@ mod tests {
         )
         .unwrap();
 
-        let outcomes = reclassify_sessions(&conn, false, false).unwrap();
+        let outcomes = reclassify_sessions(&mut conn, false, false).unwrap();
 
         assert_eq!(
             session_type_of(&conn, "fresh").as_deref(),

--- a/src/search.rs
+++ b/src/search.rs
@@ -58,6 +58,9 @@ pub struct SearchOptions {
     pub limit: usize,
     /// How to treat the invoking session (see `CurrentSession`).
     pub current: CurrentSession,
+    /// Include sessions tagged automated. Default false: automated sessions
+    /// (hook/script/agent-generated) are excluded from results (#24).
+    pub include_automated: bool,
     /// Override current time (epoch ms) for deterministic testing.
     pub now_ms: Option<i64>,
 }
@@ -70,6 +73,7 @@ impl Default for SearchOptions {
             source: None,
             limit: 10,
             current: CurrentSession::Ignore,
+            include_automated: false,
             now_ms: None,
         }
     }
@@ -130,6 +134,26 @@ fn append_current_session_filter(
     params.push(Box::new(id.clone()));
 }
 
+/// Append a NULL-safe automated-session exclusion. `session_type` lives on
+/// `sessions` (not on the messages / qa_chunks candidate tables), so the filter is
+/// a subquery on session_id. `COALESCE` treats a NULL / unclassified session_type
+/// as interactive, so sessions indexed before classification are never hidden by
+/// default. `include_automated` skips it. Called on both candidate paths — the RRF
+/// merge re-unions both sets, so a single-path filter would leak — matching
+/// `append_current_session_filter`. Emits no `?` placeholders (the labels are
+/// compile-time literals), so callers' param counts are unaffected.
+fn append_automated_filter(sql: &mut String, column: &'static str, include_automated: bool) {
+    if include_automated {
+        return;
+    }
+    sql.push_str(" AND ");
+    sql.push_str(column);
+    sql.push_str(
+        " IN (SELECT s3.session_id FROM sessions s3 \
+         WHERE COALESCE(s3.session_type, 'interactive') <> 'automated')",
+    );
+}
+
 fn build_fts_candidate_query(
     fts_query: &str,
     opts: &SearchOptions,
@@ -140,6 +164,7 @@ fn build_fts_candidate_query(
     let mut params: Vec<Box<dyn ToSql>> = vec![Box::new(fts_query.to_owned())];
     append_session_filter(&mut sql, &mut params, "session_id", opts, now_ms);
     append_current_session_filter(&mut sql, &mut params, "session_id", &opts.current);
+    append_automated_filter(&mut sql, "session_id", opts.include_automated);
     sql.push_str(" GROUP BY session_id ORDER BY best_rank LIMIT ?");
     let candidate_limit = opts.limit * CANDIDATE_LIMIT_MULTIPLIER;
     params.push(Box::new(candidate_limit as i64));
@@ -411,6 +436,7 @@ fn vec_search(
     let mut filter_params: Vec<Box<dyn ToSql>> = Vec::new();
     append_session_filter(&mut sql, &mut filter_params, "c.session_id", opts, now_ms);
     append_current_session_filter(&mut sql, &mut filter_params, "c.session_id", &opts.current);
+    append_automated_filter(&mut sql, "c.session_id", opts.include_automated);
     sql.push_str(" GROUP BY c.session_id ORDER BY d");
 
     let limit_i64 = limit as i64;
@@ -1370,6 +1396,102 @@ mod tests {
             .into_iter()
             .map(|r| r.session.session_id)
             .collect()
+    }
+
+    fn set_session_type(conn: &Connection, sid: &str, session_type: &str) {
+        conn.execute(
+            "UPDATE sessions SET session_type = ?2 WHERE session_id = ?1",
+            rusqlite::params![sid, session_type],
+        )
+        .unwrap();
+    }
+
+    fn fts_ids(conn: &Connection, opts: &SearchOptions) -> Vec<String> {
+        search(conn, "authentication", opts)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.session.session_id)
+            .collect()
+    }
+
+    // T-005 (#24/FR-005,FR-006) + T-006 (#24/FR-011): default search excludes an
+    // automated session but keeps a NULL-session_type (unclassified) one — NULL is
+    // treated as interactive (COALESCE), so pre-classification sessions never vanish.
+    #[test]
+    fn test_default_search_excludes_automated_keeps_null() {
+        let (_dir, conn) = setup_test_db();
+        insert_session(&conn, "auto", "claude", "/proj", 1709251200000);
+        insert_message(&conn, "auto", "user", "authentication flow");
+        set_session_type(&conn, "auto", "automated");
+        // "null" keeps its NULL session_type (insert_session does not set it).
+        insert_session(&conn, "null", "claude", "/proj", 1709251200000);
+        insert_message(&conn, "null", "user", "authentication flow");
+
+        let ids = fts_ids(&conn, &SearchOptions::default());
+
+        assert!(
+            !ids.contains(&"auto".to_owned()),
+            "automated session must be excluded by default: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"null".to_owned()),
+            "NULL session_type must stay visible (interactive): {ids:?}"
+        );
+    }
+
+    // T-008 (#24/FR-007): include_automated surfaces automated sessions.
+    #[test]
+    fn test_include_automated_surfaces_automated() {
+        let (_dir, conn) = setup_test_db();
+        insert_session(&conn, "auto", "claude", "/proj", 1709251200000);
+        insert_message(&conn, "auto", "user", "authentication flow");
+        set_session_type(&conn, "auto", "automated");
+
+        let ids = fts_ids(
+            &conn,
+            &SearchOptions {
+                include_automated: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            ids.contains(&"auto".to_owned()),
+            "include_automated must surface automated: {ids:?}"
+        );
+    }
+
+    // T-007 (#24/FR-006): the automated exclusion applies on the vec path too — an
+    // automated session reachable only via vector search is dropped by default.
+    #[test]
+    fn test_default_hybrid_excludes_automated_on_vec_path() {
+        let (_dir, conn) = setup_test_db();
+        let now_ms = 1_750_000_000_000_i64;
+        let embedder = MockEmbedder::new();
+        insert_session(&conn, "keep", "claude", "/proj", now_ms);
+        insert_message(&conn, "keep", "user", "authentication flow discussion");
+        // "auto" is reachable only via the vec path (chunk embedding, no FTS row).
+        insert_session(&conn, "auto", "claude", "/proj", now_ms);
+        insert_chunk_with_embedding(&conn, 1, "auto", "authentication", now_ms);
+        set_session_type(&conn, "auto", "automated");
+
+        let ids = hybrid_search_ids(
+            &conn,
+            &embedder,
+            &SearchOptions {
+                now_ms: Some(now_ms),
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            !ids.contains(&"auto".to_owned()),
+            "automated vec-only session must be excluded by default: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"keep".to_owned()),
+            "non-automated session must remain: {ids:?}"
+        );
     }
 
     // T-CS002: CurrentSession::Exclude drops the invoking session from BOTH the

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -587,3 +587,47 @@ fn only_current_without_env_exits_usage() {
         64
     );
 }
+
+// T-CLI024 (#24 Phase 3): `recall classify` reports outcomes end to end, and
+// --dry-run previews without persisting. The session's first user turn is a
+// slash-command wrapper, so it classifies automated.
+#[test]
+fn classify_reports_and_dry_run_previews() {
+    let dir = TempDir::new().unwrap();
+    let claude_dir = dir.path().join("claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("s1.jsonl"),
+        r#"{"type":"user","cwd":"/proj","message":{"role":"user","content":"<command-message>clear</command-message>"},"timestamp":"2026-03-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        exit_code(
+            recall(dir.path())
+                .env("RECALL_CLAUDE_DIR", &claude_dir)
+                .arg("index")
+        ),
+        0,
+        "index should build the DB and exit 0"
+    );
+
+    let dry = recall(dir.path())
+        .args(["classify", "--all", "--dry-run"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(
+        dry.status.code(),
+        Some(0),
+        "classify --dry-run should exit 0"
+    );
+    let dry_out = String::from_utf8_lossy(&dry.stdout);
+    assert!(dry_out.contains("dry-run"), "dry-run output: {dry_out}");
+
+    let run = recall(dir.path())
+        .args(["classify", "--all"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(run.status.code(), Some(0), "classify --all should exit 0");
+    let out = String::from_utf8_lossy(&run.stdout);
+    assert!(out.contains("classified"), "classify output: {out}");
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -631,3 +631,74 @@ fn classify_reports_and_dry_run_previews() {
     let out = String::from_utf8_lossy(&run.stdout);
     assert!(out.contains("classified"), "classify output: {out}");
 }
+
+// T-CLI025 (#24 audit/N): a default search surfaces a note that automated sessions
+// are excluded, so an AI-agent consumer can discover --include-automated.
+#[test]
+fn search_notes_automated_exclusion() {
+    let dir = TempDir::new().unwrap();
+    let claude_dir = dir.path().join("claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("auto.jsonl"),
+        r#"{"type":"user","cwd":"/proj","message":{"role":"user","content":"<command-message>clear</command-message>"},"timestamp":"2026-03-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+    fs::write(
+        claude_dir.join("human.jsonl"),
+        r#"{"type":"user","cwd":"/proj","message":{"role":"user","content":"authentication notes"},"timestamp":"2026-03-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        exit_code(
+            recall(dir.path())
+                .env("RECALL_CLAUDE_DIR", &claude_dir)
+                .arg("index")
+        ),
+        0
+    );
+
+    let out = recall(dir.path())
+        .args(["search", "authentication", "--no-embed", "--json"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "search should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--include-automated"),
+        "default search must note the automated exclusion: {stdout}"
+    );
+}
+
+// T-CLI026 (#24 audit/N): when the index has no automated sessions, the search
+// output carries no exclusion note (the hint does not appear spuriously).
+#[test]
+fn search_omits_automated_note_when_none_excluded() {
+    let dir = TempDir::new().unwrap();
+    let claude_dir = dir.path().join("claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("human.jsonl"),
+        r#"{"type":"user","cwd":"/proj","message":{"role":"user","content":"authentication notes"},"timestamp":"2026-03-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        exit_code(
+            recall(dir.path())
+                .env("RECALL_CLAUDE_DIR", &claude_dir)
+                .arg("index")
+        ),
+        0
+    );
+
+    let out = recall(dir.path())
+        .args(["search", "authentication", "--no-embed", "--json"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "search should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("--include-automated"),
+        "no automated sessions means no exclusion note: {stdout}"
+    );
+}


### PR DESCRIPTION
## 概要

hook / script / subagent が自動生成した非対話セッションが `recall search` のノイズになる問題（#24）を解消する。各セッションの先頭 user turn を組込マーカーで `interactive` / `automated` に分類し、既定で `automated` を検索結果から除外する。OUTCOME Behavior 1（AI エージェントが 1 検索で目的セッションに到達）に直結。

## 実装（3 Phase）

- Phase 1 (94a3d9f): `src/classify.rs`（組込 literal マーカー・`classify_first_turn`・zero dep）+ `sessions.session_type` 列（非破壊 ALTER migrate）+ ingest 時タグ付け（`upsert_session`）。
- Phase 2 (7134b6a): FTS・vec 両候補クエリに NULL 安全な automated 除外（`append_automated_filter`）+ `--include-automated` フラグ。
- Phase 3 (78aaea9): `recall classify [--all|--dry-run]` で既存セッションを遡及分類。

## 設計判断

- ユーザー編集 config ファイル / `regex` / `toml` は**非目標**。recall の主消費者は AI エージェントで、automated マーカーは Claude/Codex エコシステム固有（XML ラッパ・agent prompt・継続マーカー）ゆえツール組込が適切。人間編集 UX は不要（**新規依存ゼロ**、binary-size OUTCOME に整合）。critic-design 反証で確定（config 案は REJECT/要変更、組込ルール案を採用）。
- NULL 安全: `COALESCE(session_type, 'interactive') <> 'automated'` で分類前の既存セッション（NULL）が既定検索から消えない。
- 実データ（~/.recall.db, 5899 sessions）で先頭 user turn の automated マーカーが安定した literal prefix であることを確認し、`starts_with` 分離の安全性を実証。

## 監査（マージ前 self-review）

branch に `/audit`（10 reviewer → challenge → verify → causation）を実施し、真の in-scope 欠陥を db298d9 で修正:

- `reclassify_sessions` の一括 UPDATE を単一トランザクション化（per-row autocommit → 1 commit、中断時 all-or-nothing で再実行可）。indexer / migrate のトランザクション慣習に整合（5 reviewer 収束・challenger/verifier 確証）。
- dry-run 用 excerpt を dry-run 経路でのみ計算（write 経路の確保を排除）。
- `recall search` の automated 既定除外を best-effort note で告知し、エージェントが `--include-automated` を発見可能に（count 失敗時は note を出さず検索は継続）。

却下 / defer: ingest が手動 classify を上書き = **REFUTED**（classify と ingest は同一の決定的分類器を使い、分岐状態が存在し得ない）。`COALESCE` の非インデックス化 = LOW（検索予算の約 0.1%・意図的な NULL 安全設計、計測後に判断）。duplication / placement / migrate-sniff = 既存コードベースのパターンと整合。

## テスト

T-001〜T-003（classify）・T-004（ingest）・T-009（migration）・T-005〜T-008（search filter, NULL 可視性回帰含む）・T-010〜T-012（recall classify）・T-CLI024〜T-CLI026（E2E）。**200 tests green**・`clippy --all-targets -D warnings` clean・`fmt --check` OK・diff-cover 99%。

Closes #24
