### PR TITLE
#123 audit followup: vec_chunks の batch delete 化と coverage filter の self-test 追加

### DIFF
--- a/.github/scripts/filter_lcov_cfg_test.py
+++ b/.github/scripts/filter_lcov_cfg_test.py
@@ -15,6 +15,11 @@ from pathlib import Path
 
 
 def brace_delta(line: str) -> int:
+    # NOTE: counts raw `{`/`}` including those inside string literals, char
+    # literals, and comments. This miscounts lines like `write!(buf, "{{")`, but
+    # no current recall source triggers it (multi-line raw-string JSON braces in
+    # the tests are balanced and net to zero). A correct fix needs a Rust
+    # tokenizer; tracked as a followup. See test_filter_lcov_cfg_test.py xfails.
     return line.count("{") - line.count("}")
 
 

--- a/.github/scripts/test_filter_lcov_cfg_test.py
+++ b/.github/scripts/test_filter_lcov_cfg_test.py
@@ -1,0 +1,117 @@
+"""Unit tests for filter_lcov_cfg_test.py (the coverage-gate cfg(test) filter).
+
+Run: python3 -m pytest .github/scripts/test_filter_lcov_cfg_test.py
+
+The filter sits between `cargo llvm-cov` and `diff-cover`, so a brace-counting
+bug that misclassifies production code as test code silently weakens the 95%
+gate. These tests pin the current raw-count behavior and document its known
+limitation (string-literal braces) as xfail until a Rust tokenizer replaces the
+heuristic.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from filter_lcov_cfg_test import brace_delta, cfg_test_ranges  # noqa: E402
+
+# Known limitation: brace_delta counts raw `{`/`}` including those inside string
+# literals / char literals / comments. No current recall source triggers a wrong
+# coverage range (multi-line raw-string JSON braces are balanced), so a proper
+# fix (a Rust tokenizer) is deferred. These xfails document the gap honestly
+# without forcing a regex masking implementation that broke multi-line raw
+# strings in src/indexer.rs.
+_TOKENIZER_LIMITATION = "brace counting miscounts string-literal braces; needs a Rust tokenizer (followup)"
+
+
+def test_brace_delta_counts_structural_braces():
+    assert brace_delta("mod tests {") == 1
+    assert brace_delta("}") == -1
+    assert brace_delta("fn f() {}") == 0
+
+
+@pytest.mark.xfail(reason=_TOKENIZER_LIMITATION, strict=False)
+def test_brace_delta_ignores_braces_in_string_literals():
+    assert brace_delta('    write!(buf, "{{")?;') == 0
+    assert brace_delta('    let s = "}";') == 0
+
+
+@pytest.mark.xfail(reason=_TOKENIZER_LIMITATION, strict=False)
+def test_brace_delta_ignores_char_literal_and_line_comment_braces():
+    assert brace_delta("    let c = '{';") == 0
+    assert brace_delta("    foo(); // a trailing { brace") == 0
+
+
+@pytest.mark.xfail(reason=_TOKENIZER_LIMITATION, strict=False)
+def test_cfg_test_ranges_brace_in_string_does_not_swallow_following_production(tmp_path):
+    # Aspirational: an unbalanced brace in a test string literal should not
+    # extend the ignored range into the production fn that follows. Raw-count
+    # cannot do this; documented as the followup tokenizer fix.
+    src = tmp_path / "x.rs"
+    src.write_text(
+        "#[cfg(test)]\n"  # 1
+        "mod tests {\n"  # 2
+        '    fn t() { assert_eq!(x, "{"); }\n'  # 3  unbalanced `{` in string
+        "}\n"  # 4
+        "pub fn prod() -> i32 { 1 }\n",  # 5  production AFTER
+        encoding="utf-8",
+    )
+    ranges = cfg_test_ranges(src)
+    assert {1, 2, 3, 4} <= ranges
+    assert 5 not in ranges
+
+
+def test_cfg_test_ranges_excludes_balanced_test_module(tmp_path):
+    # The common case in recall: a `#[cfg(test)] mod tests` whose braces are
+    # balanced (no stray string-literal brace). Raw-count handles this correctly
+    # and is what keeps real source files (embedder/indexer/main) at 100%.
+    src = tmp_path / "x.rs"
+    src.write_text(
+        "pub fn prod() -> i32 {\n"  # 1 production
+        "    1\n"  # 2
+        "}\n"  # 3
+        "\n"  # 4
+        "#[cfg(test)]\n"  # 5
+        "mod tests {\n"  # 6
+        "    fn t() {}\n"  # 7
+        "}\n",  # 8
+        encoding="utf-8",
+    )
+    ranges = cfg_test_ranges(src)
+    assert 1 not in ranges and 2 not in ranges and 3 not in ranges
+    assert {6, 7, 8} <= ranges
+
+
+def test_cfg_test_ranges_balanced_multiline_raw_string(tmp_path):
+    # Regression guard for the indexer.rs breakage: a multi-line raw string with
+    # balanced JSON braces inside the test module must NOT truncate the range.
+    # Raw-count passes because the JSON braces net to zero.
+    src = tmp_path / "x.rs"
+    src.write_text(
+        "#[cfg(test)]\n"  # 1
+        "mod tests {\n"  # 2
+        "    fn t() {\n"  # 3
+        '        let s = r#"{"a":{"b":1}}\n'  # 4  multi-line raw string opens
+        '{"c":2}"#;\n'  # 5  ...and closes; JSON braces balanced
+        "        assert!(s.len() > 0);\n"  # 6
+        "    }\n"  # 7
+        "}\n",  # 8
+        encoding="utf-8",
+    )
+    ranges = cfg_test_ranges(src)
+    assert {6, 7, 8} <= ranges, "balanced multi-line raw string must not truncate the range"
+
+
+def test_cfg_test_ranges_non_rs_file_returns_empty(tmp_path):
+    p = tmp_path / "x.txt"
+    p.write_text("#[cfg(test)]\nmod tests {}\n", encoding="utf-8")
+    assert cfg_test_ranges(p) == set()
+
+
+def test_cfg_test_ranges_missing_file_returns_empty(tmp_path):
+    assert cfg_test_ranges(tmp_path / "nonexistent.rs") == set()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,14 @@ jobs:
       - name: Generate lcov coverage
         run: cargo llvm-cov --lcov --output-path lcov.info
 
+      - name: Test coverage filter script
+        run: |
+          # The cfg(test) filter gates coverage; a brace-counting regression
+          # could silently strip production lines, so test it before use.
+          python3 -m venv /tmp/pytest-venv
+          /tmp/pytest-venv/bin/pip install --quiet pytest
+          /tmp/pytest-venv/bin/python -m pytest .github/scripts/test_filter_lcov_cfg_test.py -q
+
       - name: Exclude inline Rust test code from coverage
         run: |
           python3 .github/scripts/filter_lcov_cfg_test.py \

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -55,10 +55,20 @@ fn embed_chunks(
         match embedder.embed_documents_batch(&texts) {
             Ok(embeddings) => {
                 let tx = conn.transaction()?;
+                // Idempotent replay guard for stale concurrent work that reached
+                // this tx after the NOT EXISTS pending query. Batched into one
+                // IN-delete: vec0's +chunk_id is an unindexed auxiliary column, so
+                // each `DELETE WHERE chunk_id = ?` is a full O(N) scan (EXPLAIN
+                // reports "SCAN vec_chunks VIRTUAL TABLE") — per-chunk deletes were
+                // O(batch × N). Keyed on batch_idx (non-empty by the early return);
+                // on the NOT EXISTS path nothing matches, so it is a no-op there.
+                let batch_ids: Vec<i64> = batch_idx.iter().map(|&i| chunks[i].0).collect();
+                let placeholders = anon_placeholders(batch_ids.len());
+                tx.execute(
+                    &format!("DELETE FROM vec_chunks WHERE chunk_id IN ({placeholders})"),
+                    rusqlite::params_from_iter(batch_ids.iter()),
+                )?;
                 for (chunked, &i) in embeddings.iter().zip(batch_idx) {
-                    // Idempotent replay guard: stale concurrent work may still
-                    // reach this tx after the NOT EXISTS pending query.
-                    tx.execute("DELETE FROM vec_chunks WHERE chunk_id = ?1", [chunks[i].0])?;
                     for (sub_idx, sub_emb) in chunked.chunks.iter().enumerate() {
                         let embedding_bytes = f32_as_bytes(sub_emb);
                         tx.execute(


### PR DESCRIPTION
## 概要

PR #123 の /audit で確認された findings のうち、緑で検証できた 2 件（RC-1 / RC-3）を取り込む。残りは #124–#126 で追跡。

## 変更

### RC-1 (PERF-002): vec_chunks の per-chunk DELETE を batch IN-delete に

- `vec_chunks` は vec0 仮想テーブルで `+chunk_id` が非インデックスの auxiliary column のため、`DELETE WHERE chunk_id = ?` は full O(N) scan（**実測**: `EXPLAIN` = `SCAN vec_chunks VIRTUAL TABLE`）。per-chunk ループで O(batch × N) だった。
- batch 単位の 1 回の `DELETE ... WHERE chunk_id IN (...)` に hoist（`batch_idx` keyed、早期 return で非空保証、bind placeholder 使用）。
- 冪等性維持（既存 replay テスト通過）。通常の NOT EXISTS パスでは 0 行マッチで no-op。

### RC-3: coverage filter の self-test 追加 + 限界の文書化

- `filter_lcov_cfg_test.py` に pytest suite を追加し、CI で filter 使用前に実行（cfg(test) 範囲検出の regression が silent に gate を弱めるのを防ぐ）。
- `brace_delta` は raw count を維持（regex マスキングは `indexer.rs` の複数行 raw string で範囲検出を壊したため revert）。文字列リテラルの限界は `xfail` で文書化、token-aware 化は #124 で追跡。

## テスト

1. `cargo test`（208 pass）
2. `cargo clippy --all-targets --all-features -- -D warnings`（clean）
3. `python3 -m pytest .github/scripts/test_filter_lcov_cfg_test.py`（5 pass + 3 xfail）
4. coverage gate: ローカル diff-cover で 96%（≥95%）を確認

## 関連

- Follows up #123 audit
- Refs #124（RC-3 の token-aware followup）
