### PR TITLE
embed の失敗 batch を跨いで継続し、停止を index --json に表面化

### DIFF
--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -23,10 +23,10 @@ impl EmbedResult {
         if self.failed_count > 0 {
             // first_error is always Some when failed_count > 0 (both are set in
             // embed_chunks' Err arm together); the fallback is defensive only.
+            let first_error = self.first_error.as_deref().unwrap_or("unknown");
             warn!(
                 failed_count = self.failed_count,
-                first_error = self.first_error.as_deref().unwrap_or("unknown"),
-                "embedding skipped chunks after batch failures"
+                first_error, "embedding skipped chunks after batch failures"
             );
         }
     }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -14,13 +14,20 @@ use tracing::warn;
 #[derive(Default)]
 pub(crate) struct EmbedResult {
     pub embedded: usize,
-    pub stopped_at_error: Option<String>,
+    pub failed_count: usize,
+    pub first_error: Option<String>,
 }
 
 impl EmbedResult {
-    pub(crate) fn warn_if_stopped(&self) {
-        if let Some(ref err) = self.stopped_at_error {
-            warn!(error = %err, "embedding stopped early");
+    pub(crate) fn warn_if_batches_failed(&self) {
+        if self.failed_count > 0 {
+            // first_error is always Some when failed_count > 0 (both are set in
+            // embed_chunks' Err arm together); the fallback is defensive only.
+            warn!(
+                failed_count = self.failed_count,
+                first_error = self.first_error.as_deref().unwrap_or("unknown"),
+                "embedding skipped chunks after batch failures"
+            );
         }
     }
 }
@@ -48,7 +55,8 @@ fn embed_chunks(
 
     let total = chunks.len();
     let mut embedded = 0;
-    let mut stopped_at_error = None;
+    let mut failed_count = 0;
+    let mut first_error = None;
 
     for batch_idx in sorted.chunks(EMBED_BATCH_SIZE) {
         let texts: Vec<&str> = batch_idx.iter().map(|&i| chunks[i].1.as_str()).collect();
@@ -85,15 +93,22 @@ fn embed_chunks(
                 }
             }
             Err(e) => {
-                stopped_at_error = Some(format!("batch: {e}"));
-                break;
+                // Skip the failed batch and keep going: a poison chunk fails its
+                // whole ≤128-batch (all-or-nothing) but must not block the rest of
+                // the backlog. The chunks stay pending (no tx committed here) for
+                // the next index to retry via the NOT EXISTS gate.
+                failed_count += batch_idx.len();
+                if first_error.is_none() {
+                    first_error = Some(format!("batch: {e}"));
+                }
             }
         }
     }
 
     Ok(EmbedResult {
         embedded,
-        stopped_at_error,
+        failed_count,
+        first_error,
     })
 }
 
@@ -144,6 +159,7 @@ pub(crate) fn embed_recent_chunks(
 pub(crate) struct MockEmbedder {
     call_count: AtomicUsize,
     fail_after: Option<usize>,
+    fail_on_text: Option<String>,
 }
 
 #[cfg(test)]
@@ -152,6 +168,7 @@ impl MockEmbedder {
         Self {
             call_count: AtomicUsize::new(0),
             fail_after: None,
+            fail_on_text: None,
         }
     }
 
@@ -159,6 +176,17 @@ impl MockEmbedder {
         Self {
             call_count: AtomicUsize::new(0),
             fail_after: Some(n),
+            fail_on_text: None,
+        }
+    }
+
+    /// A mock that fails any batch containing `text` (all-or-nothing, matching
+    /// `embed_chunks`'s batch semantics). T-001 uses it to poison one batch.
+    pub(crate) fn failing_on_text(text: &str) -> Self {
+        Self {
+            call_count: AtomicUsize::new(0),
+            fail_after: None,
+            fail_on_text: Some(text.to_owned()),
         }
     }
 
@@ -202,6 +230,19 @@ impl Embed for MockEmbedder {
         )]))
     }
 
+    /// Explicit impl of the production dispatch target: `embed_chunks` calls this
+    /// method, so the poison check lives here (all-or-nothing per batch), not in
+    /// the per-item delegate. Being explicit also survives rurico revisions where
+    /// the trait's default body is removed (required at rurico HEAD).
+    fn embed_documents_batch(&self, texts: &[&str]) -> Result<Vec<ChunkedEmbedding>, EmbedError> {
+        if let Some(poison) = self.fail_on_text.as_deref()
+            && texts.contains(&poison)
+        {
+            return Err(EmbedError::Inference(format!("poison text: {poison}")));
+        }
+        texts.iter().map(|t| self.embed_document(t)).collect()
+    }
+
     fn embed_text(&self, text: &str, _prefix: &str) -> Result<Vec<f32>, EmbedError> {
         Ok(Self::deterministic_vector(text))
     }
@@ -220,7 +261,7 @@ mod tests {
         let embedder = MockEmbedder::new();
         let result = embed_recent_chunks(&mut conn, &embedder, 0, None).unwrap();
         assert_eq!(result.embedded, 0);
-        assert!(result.stopped_at_error.is_none());
+        assert_eq!(result.failed_count, 0);
     }
 
     #[test]
@@ -297,32 +338,156 @@ mod tests {
         assert_eq!(vec_count, 1, "re-embedding must not duplicate vec rows");
     }
 
-    // T-009 (FR-002): a failed embed batch during index is non-fatal and retryable.
-    // embed_recent_chunks records the stop and returns Ok (so the index does not
-    // abort), and the chunk keeps no vec row, so the next index retries it via the
-    // NOT EXISTS gate.
-    #[test]
-    fn test_embed_recent_chunks_batch_failure_is_non_fatal_and_retryable() {
-        let (_dir, mut conn) = setup_test_db();
+    /// Seed `count` qa_chunks whose content is the given closure of the row id, so
+    /// a test controls each chunk's text (and thus its length-sort batch). Returns
+    /// nothing; the rows live in `conn`.
+    fn seed_chunks(conn: &Connection, count: usize, content: impl Fn(i64) -> String) {
         conn.execute(
             "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
             [],
         )
         .unwrap();
+        for id in 1..=count as i64 {
+            conn.execute(
+                "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+                 VALUES (?1, 's1', ?2, 0)",
+                rusqlite::params![id, content(id)],
+            )
+            .unwrap();
+        }
+    }
+
+    // Decision table for embed_chunks under a one-batch poison (EMBED_BATCH_SIZE=128):
+    // | batch | contains poison "x" | embed_documents_batch | committed | counted as |
+    // | ----- | ------------------- | --------------------- | --------- | ---------- |
+    // | 1     | yes (sorted first)  | Err (all-or-nothing)  | no        | failed     |
+    // | 2     | no                  | Ok                    | yes       | embedded   |
+    //
+    // T-001 (FR-001, FR-002): a poison batch does not stop the next batch. Given 129
+    // chunks — poison text "x" (shortest, so it sorts into batch 1) plus 128 longer
+    // "content_NNNN" texts — and failing_on_text("x"), embed_chunks continues past
+    // the failed batch 1: batch 2 (1 chunk) embeds, batch 1 (128 chunks) is counted
+    // failed, and the first batch error is reported.
+    // Perspective: branch (the Err arm now continues, not breaks) + boundary (the
+    // batch-1/batch-2 split at EMBED_BATCH_SIZE).
+    #[test]
+    fn test_embed_chunks_poison_batch_does_not_block_next_batch() {
+        let (_dir, mut conn) = setup_test_db();
+        // 128 healthy chunks (uniform length 12, all longer than "x") + 1 poison.
+        // Ascending length-sort puts "x" at index 0 → batch 1 (with 127 healthy);
+        // the single remaining healthy chunk is batch 2.
+        seed_chunks(&conn, 128, |id| format!("content_{id:04}"));
         conn.execute(
             "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
-             VALUES (1, 's1', 'pending content', 0)",
+             VALUES (129, 's1', 'x', 0)",
             [],
         )
         .unwrap();
 
+        let chunks: Vec<(i64, String)> = {
+            let mut stmt = conn
+                .prepare("SELECT id, content FROM qa_chunks ORDER BY id")
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+                .unwrap()
+                .map(StdResult::unwrap)
+                .collect()
+        };
+        assert_eq!(chunks.len(), 129, "129 chunks span exactly two batches");
+
+        let embedder = MockEmbedder::failing_on_text("x");
+        let result = embed_chunks(&mut conn, &embedder, &chunks, None).unwrap();
+
+        assert_eq!(
+            result.embedded, 1,
+            "batch 2 (the single non-poison chunk) embeds despite batch 1 failing"
+        );
+        assert_eq!(
+            result.failed_count, 128,
+            "the whole poison batch (128 chunks) is counted failed, not just the poison chunk"
+        );
+        let err = result.first_error.as_deref().unwrap_or_default();
+        assert!(
+            err.contains("poison text: x"),
+            "first_error carries the batch error content, not a fallback, got: {err:?}"
+        );
+    }
+
+    // T-002 (FR-003): chunks in a failed batch keep no embedding so the next index
+    // retries them. Given the same poison batch as T-001, after embed_chunks the
+    // poison batch's 128 chunks have no vec_chunks row (the failed batch's tx never
+    // commits), while batch 2's single chunk does. The pending set (NOT EXISTS) is
+    // exactly the failed batch.
+    // Perspective: hazard (a half-applied batch would leave a chunk embedded with no
+    // record, or strand a poison chunk as permanently skipped).
+    #[test]
+    fn test_embed_chunks_failed_batch_leaves_chunks_pending() {
+        let (_dir, mut conn) = setup_test_db();
+        seed_chunks(&conn, 128, |id| format!("content_{id:04}"));
+        conn.execute(
+            "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+             VALUES (129, 's1', 'x', 0)",
+            [],
+        )
+        .unwrap();
+
+        let chunks: Vec<(i64, String)> = {
+            let mut stmt = conn
+                .prepare("SELECT id, content FROM qa_chunks ORDER BY id")
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+                .unwrap()
+                .map(StdResult::unwrap)
+                .collect()
+        };
+
+        let embedder = MockEmbedder::failing_on_text("x");
+        embed_chunks(&mut conn, &embedder, &chunks, None).unwrap();
+
+        let vec_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            vec_count, 1,
+            "only batch 2's chunk is embedded; the failed poison batch commits nothing"
+        );
+        let pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM qa_chunks c \
+                 WHERE NOT EXISTS (SELECT 1 FROM vec_chunks v WHERE v.chunk_id = c.id)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            pending, 128,
+            "the failed batch's 128 chunks stay pending for the next index to retry"
+        );
+    }
+
+    // T-007 (FR-002, FR-004): when every batch fails, the embed run is non-fatal and
+    // fully retryable. Given 1 pending chunk and failing_after(0) (every batch
+    // fails), embed_recent_chunks returns Ok (the index does not abort), counts the
+    // whole batch as failed, and leaves no vec row so the next index retries it.
+    // (Updated from the old T-009: stopped_at_error.is_some() → failed_count > 0.)
+    // Perspective: error (the all-fail path) + boundary (failed_count == every chunk).
+    #[test]
+    fn test_embed_recent_chunks_all_batches_fail_is_non_fatal_and_retryable() {
+        let (_dir, mut conn) = setup_test_db();
+        seed_chunks(&conn, 1, |_| "pending content".to_owned());
+
         let embedder = MockEmbedder::failing_after(0);
         let result = embed_recent_chunks(&mut conn, &embedder, 10, None).unwrap();
 
-        assert_eq!(result.embedded, 0, "the failed batch embeds nothing");
+        assert_eq!(result.embedded, 0, "every batch failed, so nothing embeds");
+        assert_eq!(
+            result.failed_count, 1,
+            "the sole batch's chunk count is reported as failed"
+        );
+        let err = result.first_error.as_deref().unwrap_or_default();
         assert!(
-            result.stopped_at_error.is_some(),
-            "the batch failure is recorded, not silently dropped"
+            err.contains("mock failure"),
+            "the all-fail run still records the first batch error, got: {err:?}"
         );
         let vec_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
@@ -331,5 +496,49 @@ mod tests {
             vec_count, 0,
             "the chunk stays pending for the next index to retry"
         );
+    }
+
+    // T-008 (FR-003): the failed batch is actually picked up by the next run — the
+    // cross-invocation half of T-002's "stays pending" promise (OUTCOME Behavior 2:
+    // repeated `recall index` fills the un-embedded chunks). Given the T-001 poison
+    // state (batch 1 failed, 128 pending), a second embed_recent_chunks with a
+    // healthy embedder embeds exactly those 128 and leaves nothing pending.
+    // Perspective: state (a two-invocation invariant that single-run C0/C1 misses).
+    #[test]
+    fn test_embed_recent_chunks_second_run_embeds_previously_failed_batch() {
+        let (_dir, mut conn) = setup_test_db();
+        seed_chunks(&conn, 128, |id| format!("content_{id:04}"));
+        conn.execute(
+            "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+             VALUES (129, 's1', 'x', 0)",
+            [],
+        )
+        .unwrap();
+
+        // Run 1: the poison strands batch 1 (its accounting is T-001/T-002's job).
+        let poisoned = MockEmbedder::failing_on_text("x");
+        let first = embed_recent_chunks(&mut conn, &poisoned, 129, None).unwrap();
+        assert_eq!(
+            first.embedded, 1,
+            "precondition: only batch 2 embeds on run 1"
+        );
+
+        // Run 2: a healthy embedder picks the 128 up via the NOT EXISTS gate.
+        let healthy = MockEmbedder::new();
+        let second = embed_recent_chunks(&mut conn, &healthy, 129, None).unwrap();
+        assert_eq!(
+            second.embedded, 128,
+            "the previously failed batch embeds on the retry run"
+        );
+        assert_eq!(second.failed_count, 0, "nothing fails on the healthy retry");
+        let pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM qa_chunks c \
+                 WHERE NOT EXISTS (SELECT 1 FROM vec_chunks v WHERE v.chunk_id = c.id)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(pending, 0, "no chunk is left behind after the retry");
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -990,7 +990,7 @@ mod tests {
         let result = embed_recent_chunks(&mut conn, &embedder, 100, None).unwrap();
 
         assert_eq!(result.embedded, usize::try_from(chunk_count).unwrap());
-        assert!(result.stopped_at_error.is_none());
+        assert_eq!(result.failed_count, 0);
 
         let vec_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
@@ -1001,8 +1001,17 @@ mod tests {
         assert_eq!(result2.embedded, 0);
     }
 
+    // T-007 (FR-001, FR-002): a mid-run batch failure is non-blocking — the run
+    // continues past it and counts the rest as failed. With failing_after(128) the
+    // first batch (128 chunks) succeeds and commits; the MockEmbedder counter is not
+    // reset, so every later batch fails (call_count stays >= 128). Under continue the
+    // run does not stop at batch 2: it reports embedded == 128 and failed_count ==
+    // the remaining chunks, and the committed batch survives.
+    // (Updated from test_embed_chunks_stops_on_error_preserves_progress, whose
+    // stopped_at_error.is_some() assertion predates the break->continue change.)
+    // Perspective: branch (the Err arm continues) + boundary (split at EMBED_BATCH_SIZE).
     #[test]
-    fn test_embed_chunks_stops_on_error_preserves_progress() {
+    fn test_embed_chunks_continues_past_failed_batch_and_counts_remainder() {
         let (_dir, mut conn) = setup_test_db();
 
         conn.execute(
@@ -1044,16 +1053,20 @@ mod tests {
 
         assert_eq!(
             result.embedded, EMBED_BATCH_SIZE,
-            "first batch should succeed"
+            "the first batch embeds and commits before the failures start"
         );
-        assert!(result.stopped_at_error.is_some(), "should report the error");
+        let remaining = usize::try_from(chunk_count).unwrap() - EMBED_BATCH_SIZE;
+        assert_eq!(
+            result.failed_count, remaining,
+            "every batch after the first fails (counter not reset), so all remaining chunks are failed"
+        );
 
         let vec_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
             .unwrap();
         assert_eq!(
             vec_count, EMBED_BATCH_SIZE as i64,
-            "committed batch should survive"
+            "the committed first batch survives the later failures"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,18 +253,18 @@ fn search_degraded_state(load: &Result<Arc<dyn Embed>, DegradedReason>) -> (bool
 
 // -- Subcommands --
 
-fn run_index(db_path: &Option<PathBuf>) -> Result<()> {
+fn run_index(db_path: &Option<PathBuf>) -> Result<IndexOutcome> {
     index_and_report(db_path, false)
 }
 
-fn run_rebuild(db_path: &Option<PathBuf>) -> Result<()> {
+fn run_rebuild(db_path: &Option<PathBuf>) -> Result<IndexOutcome> {
     index_and_report(db_path, true)
 }
 
 /// Shared index pipeline for `index` (incremental) and `rebuild` (full).
 /// Resolves source dirs from the environment, then delegates to
 /// [`index_and_report_with`] with the real cached-embedder loader.
-fn index_and_report(db_path: &Option<PathBuf>, force: bool) -> Result<()> {
+fn index_and_report(db_path: &Option<PathBuf>, force: bool) -> Result<IndexOutcome> {
     let home = dirs::home_dir().context("Could not determine home directory")?;
     let claude_dir = indexer::resolve_claude_dir(&home);
     let codex_dir = indexer::resolve_codex_dir(&home);
@@ -278,18 +278,67 @@ fn index_and_report(db_path: &Option<PathBuf>, force: bool) -> Result<()> {
     let outcome = index_and_report_with(db_path, &opts, || {
         try_load_embedder_cached_with_reporter(open_cached_embedder, |_: &str| {})
     })?;
-    if let Some(note) = outcome.degraded_note {
-        cli_info(&note);
+    if let Some(note) = &outcome.degraded_note {
+        cli_info(note);
     }
-    Ok(())
+    Ok(outcome)
 }
 
-/// Outcome of an index run. `degraded_note` is `Some` when the embedder could not
-/// load (model-less): the index still completes FTS-only and the wrapper surfaces
-/// the note (naming `recall model download`) instead of failing. `None` means
-/// embedding completed.
+/// Outcome of an index run, surfaced to the caller for the `--json` envelope.
+/// `degraded_note` is `Some` when the embedder could not load (model-less): the
+/// index still completes FTS-only. `embedded`/`failed_count`/`first_error` report
+/// the embed pass: `failed_count > 0` means some batches failed but the index is
+/// complete and those chunks stay pending for the next run. The two degradation
+/// reasons are mutually exclusive (a model-less run skips embedding, so
+/// `failed_count == 0`).
+#[derive(Default)]
 struct IndexOutcome {
     degraded_note: Option<String>,
+    embedded: usize,
+    failed_count: usize,
+    first_error: Option<String>,
+}
+
+/// Build the `--json` envelope for an index run from its [`IndexOutcome`],
+/// mirroring [`search_degraded_state`]: both degradation reasons — a model-less
+/// load (`degraded_note`) and an embed batch failure (`failed_count`) — become
+/// `notes`, `degraded` co-varies (true iff `notes` is non-empty), and
+/// `{ embedded, failed_count }` is the data so an agent reads the magnitude, not
+/// just a boolean.
+/// Cap on the `first_error` portion of the embed-stop note (chars, not bytes, so
+/// truncation never splits a UTF-8 boundary).
+const EMBED_ERROR_NOTE_MAX_CHARS: usize = 120;
+
+fn index_command_output(outcome: &IndexOutcome) -> CommandOutput {
+    debug_assert!(
+        outcome.degraded_note.is_none() || outcome.failed_count == 0,
+        "model-absent and embed-stop degradation are mutually exclusive"
+    );
+    let mut notes = Vec::new();
+    if let Some(note) = &outcome.degraded_note {
+        notes.push(note.clone());
+    }
+    if outcome.failed_count > 0 {
+        // first_error is always Some when failed_count > 0 (both are set in
+        // embed_chunks' Err arm together); the fallback is defensive only. Like
+        // every other envelope-bound string the error is control-char-stripped,
+        // and capped so a verbose MLX error cannot bloat the note.
+        let raw = outcome.first_error.as_deref().unwrap_or("unknown error");
+        let err: String = ansi::strip_control_chars(raw)
+            .chars()
+            .take(EMBED_ERROR_NOTE_MAX_CHARS)
+            .collect();
+        notes.push(format!(
+            "{n} chunk(s) failed to embed ({err}); rerun `recall index` to retry",
+            n = outcome.failed_count,
+        ));
+    }
+    let degraded = !notes.is_empty();
+    let data = serde_json::json!({
+        "embedded": outcome.embedded,
+        "failed_count": outcome.failed_count,
+    });
+    CommandOutput::with_notes(String::new(), data, degraded, notes)
 }
 
 /// Index pipeline with an injected embedder loader. Runs FTS indexing + chunking,
@@ -335,13 +384,17 @@ where
     // so the wrapper can guide the user (FR-004a/004b).
     match load_embedder() {
         Ok(embedder) => {
-            embed_all_pending(&mut conn, embedder.as_ref())?;
+            let result = embed_all_pending(&mut conn, embedder.as_ref())?;
             Ok(IndexOutcome {
                 degraded_note: None,
+                embedded: result.embedded,
+                failed_count: result.failed_count,
+                first_error: result.first_error,
             })
         }
         Err(reason) => Ok(IndexOutcome {
             degraded_note: search_degraded_note(reason),
+            ..IndexOutcome::default()
         }),
     }
 }
@@ -349,7 +402,7 @@ where
 /// Embed every chunk absent from `vec_chunks`. Incremental by the `NOT EXISTS`
 /// gate inside `embed_recent_chunks`, so a re-index embeds only new chunks; a
 /// `rebuild` re-embeds all because its `force` DELETE cleared `vec_chunks` first.
-fn embed_all_pending(conn: &mut Connection, embedder: &dyn Embed) -> Result<()> {
+fn embed_all_pending(conn: &mut Connection, embedder: &dyn Embed) -> Result<embedder::EmbedResult> {
     let pending: i64 = conn.query_row(
         "SELECT COUNT(*) FROM qa_chunks c \
          WHERE NOT EXISTS (SELECT 1 FROM vec_chunks v WHERE v.chunk_id = c.id)",
@@ -357,7 +410,7 @@ fn embed_all_pending(conn: &mut Connection, embedder: &dyn Embed) -> Result<()> 
         |r| r.get(0),
     )?;
     if pending == 0 {
-        return Ok(());
+        return Ok(embedder::EmbedResult::default());
     }
     let pending_usize = usize::try_from(pending).expect("chunk count fits in usize");
     let sp = Spinner::new("Embedding chunks...");
@@ -371,9 +424,10 @@ fn embed_all_pending(conn: &mut Connection, embedder: &dyn Embed) -> Result<()> 
     // A mid-run batch failure is non-fatal: chunks already embedded are committed,
     // the rest stay pending, and the FTS index is complete and queryable. The next
     // `recall index` retries the remaining pending via the NOT EXISTS gate, so we
-    // warn rather than fail. (Surfacing the stop in `--json` is tracked in #130.)
-    result.warn_if_stopped();
-    Ok(())
+    // warn rather than fail. The stop is also surfaced in the index `--json`
+    // envelope via `failed_count` (index_command_output).
+    result.warn_if_batches_failed();
+    Ok(result)
 }
 
 fn run_model_download() -> Result<()> {
@@ -976,8 +1030,8 @@ fn run(cli: Cli) -> Result<CommandOutput> {
     init_subscriber(default_filter);
 
     match cli.command {
-        Some(Command::Index) => run_index(&cli.db_path).map(|()| no_payload()),
-        Some(Command::Rebuild) => run_rebuild(&cli.db_path).map(|()| no_payload()),
+        Some(Command::Index) => run_index(&cli.db_path).map(|o| index_command_output(&o)),
+        Some(Command::Rebuild) => run_rebuild(&cli.db_path).map(|o| index_command_output(&o)),
         Some(Command::Model(ModelCommand::Download)) => run_model_download().map(|()| no_payload()),
         Some(cmd @ Command::Search { .. }) => run_search(cmd, &cli.db_path),
         Some(Command::Show { session_id }) => run_show(&session_id, cli.verbose, &cli.db_path),
@@ -1990,6 +2044,195 @@ mod tests {
         assert!(
             note.contains("recall model download"),
             "the degraded note must name `recall model download` to guide the user, got: {note}"
+        );
+    }
+
+    // -- Phase 2 (D2, AC-4..7): index_command_output builds the --json envelope --
+    //
+    // index_command_output(&IndexOutcome) -> CommandOutput is the pure seam the Spec
+    // defines (FR-005): the dispatch maps run_index's IndexOutcome through it instead
+    // of no_payload(), so degradation reaches the --json envelope. Testing the pure
+    // function directly needs no DB, loader, or process env — every branch is driven
+    // by an IndexOutcome literal. The two degradations are exclusive (Spec排他):
+    // embed-stop has degraded_note=None + failed_count>0; model-absent has
+    // degraded_note=Some + failed_count=0.
+
+    /// An embed-stop outcome: the model loaded and embedded some chunks, but a batch
+    /// failed, so failed_count>0 and there is a first_error but no degraded_note.
+    fn embed_stop_outcome() -> IndexOutcome {
+        IndexOutcome {
+            degraded_note: None,
+            embedded: 5,
+            failed_count: 3,
+            first_error: Some("batch: mock failure".to_owned()),
+        }
+    }
+
+    /// A model-absent outcome: embedding was skipped, so failed_count=0 and the
+    /// degraded_note names `recall model download`.
+    fn model_absent_outcome() -> IndexOutcome {
+        IndexOutcome {
+            degraded_note: Some("note: run `recall model download` to enable.".to_owned()),
+            embedded: 0,
+            failed_count: 0,
+            first_error: None,
+        }
+    }
+
+    /// A fully successful outcome: the model loaded and every chunk embedded, so no
+    /// degraded_note, no failures, no error.
+    fn success_outcome() -> IndexOutcome {
+        IndexOutcome {
+            degraded_note: None,
+            embedded: 8,
+            failed_count: 0,
+            first_error: None,
+        }
+    }
+
+    // T-003 (FR-005, FR-006, FR-008): an embed-stop index surfaces degraded:true with
+    // a note naming the failure and the retry command, and carries both magnitudes
+    // in the payload. Given failed_count>0 + degraded_note=None,
+    // index_command_output sets degraded:true, notes[0] names the failed chunk
+    // count, the first batch error, and `recall index` (retry guidance), and the
+    // payload reports failed_count and embedded (what did land before the stop).
+    // Perspective: branch (the embed-stop arm) + error (a partial failure must be
+    // visible, not reported as success).
+    #[test]
+    fn index_command_output_surfaces_embed_stop_with_failed_count_and_retry() {
+        let out = index_command_output(&embed_stop_outcome());
+
+        assert!(
+            out.degraded,
+            "an embed-stop index is degraded: --json must not report it as a clean success"
+        );
+        assert!(
+            out.notes[0].contains("3 chunk"),
+            "the note must name how many chunks failed, got: {:?}",
+            out.notes
+        );
+        assert!(
+            out.notes[0].contains("recall index"),
+            "the note must guide the agent to retry via `recall index`, got: {:?}",
+            out.notes
+        );
+        assert!(
+            out.notes[0].contains("mock failure"),
+            "the note carries the first batch error, not the unknown-error fallback, got: {:?}",
+            out.notes
+        );
+        assert_eq!(
+            out.data["failed_count"], 3,
+            "the payload carries the failure magnitude, not just a bool"
+        );
+        assert_eq!(
+            out.data["embedded"], 5,
+            "the payload reports how many chunks did embed despite the stop"
+        );
+    }
+
+    // T-004 (FR-007): a model-absent index surfaces degraded:true with the
+    // model-download note in --json (previously stderr-only). Given
+    // degraded_note=Some(model download) + failed_count=0, index_command_output sets
+    // degraded:true and a note naming `recall model download`.
+    // Perspective: branch (the model-absent arm, exclusive with embed-stop).
+    #[test]
+    fn index_command_output_surfaces_model_absent_download_note() {
+        let out = index_command_output(&model_absent_outcome());
+
+        assert!(
+            out.degraded,
+            "a model-absent index is degraded: embedding was skipped"
+        );
+        assert!(
+            out.notes
+                .iter()
+                .any(|n| n.contains("recall model download")),
+            "the model-absent note must reach --json (not stderr only), got: {:?}",
+            out.notes
+        );
+    }
+
+    // T-005 (FR-006, FR-008, FR-009, FR-010): a fully successful index is not
+    // degraded and carries failed_count=0. Given embedded>0 + failed_count=0 +
+    // degraded_note=None, index_command_output sets degraded:false, notes:[], and
+    // data.failed_count==0.
+    // Perspective: branch (the success arm) + boundary (failed_count at its zero edge).
+    #[test]
+    fn index_command_output_clean_success_is_not_degraded() {
+        let out = index_command_output(&success_outcome());
+
+        assert!(!out.degraded, "a fully embedded index is not degraded");
+        assert!(
+            out.notes.is_empty(),
+            "a clean success carries no notes, got: {:?}",
+            out.notes
+        );
+        assert_eq!(
+            out.data["failed_count"], 0,
+            "the payload reports zero failures on success"
+        );
+        assert_eq!(
+            out.data["embedded"], 8,
+            "the payload reports how many chunks were embedded on success"
+        );
+    }
+
+    // T-006 (FR-009): degraded co-varies with notes across every outcome —
+    // degraded:true ⟺ notes non-empty — replicating search_degraded_state's
+    // invariant so the bool and the text never disagree. Checked over all three
+    // outcomes (embed-stop, model-absent, success).
+    // Perspective: combination (the (degraded, notes_empty) decision table: the
+    // (true, empty) and (false, non-empty) rows are the contradictions this forbids).
+    #[test]
+    fn index_command_output_degraded_covaries_with_notes() {
+        for outcome in [
+            embed_stop_outcome(),
+            model_absent_outcome(),
+            success_outcome(),
+        ] {
+            let out = index_command_output(&outcome);
+            assert_eq!(
+                out.degraded,
+                !out.notes.is_empty(),
+                "degraded must equal notes-non-empty (degraded={}, notes={:?})",
+                out.degraded,
+                out.notes
+            );
+        }
+    }
+
+    // T-009 (FR-006): the embed-stop note sanitizes and bounds first_error — control
+    // chars are stripped (matching every other envelope-bound string) and the error
+    // is capped so a verbose MLX error cannot bloat the note. The retry guidance
+    // must survive the capping.
+    // Perspective: boundary (an error far over the cap) + hazard (ANSI escapes
+    // forwarded raw into an agent-parsed channel).
+    #[test]
+    fn index_command_output_sanitizes_and_bounds_first_error_in_note() {
+        let outcome = IndexOutcome {
+            degraded_note: None,
+            embedded: 0,
+            failed_count: 2,
+            first_error: Some(format!("batch: \x1b[31mboom\x1b[0m {}", "e".repeat(300))),
+        };
+
+        let out = index_command_output(&outcome);
+
+        assert!(
+            !out.notes[0].contains('\x1b'),
+            "control chars are stripped from the note, got: {:?}",
+            out.notes
+        );
+        assert!(
+            out.notes[0].len() < 200,
+            "a verbose error is capped, got len {}",
+            out.notes[0].len()
+        );
+        assert!(
+            out.notes[0].contains("rerun `recall index`"),
+            "the retry guidance survives the capping, got: {:?}",
+            out.notes
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1779,118 +1779,149 @@ mod tests {
     }
 
     /// Two temp dirs that do not exist on disk. `collect_sources` gates session
-    /// scanning on `is_dir()` (indexer.rs:269), so passing absent dirs makes
-    /// `index_from_dirs` a guaranteed no-op — directly-seeded qa_chunks then drive
-    /// the embed step alone (force=false never deletes; indexer.rs:329).
+    /// scanning on `is_dir()` (indexer.rs:269), so `index_from_dirs` scans no
+    /// files — but its orphan cleanup still deletes any hand-seeded session
+    /// whose file_path has no on-disk source, chunks included. Use only where
+    /// sessions come from a real source dir (or none); embed-step tests call
+    /// `embed_all_pending` directly instead.
     fn absent_source_dirs(root: &Path) -> (PathBuf, PathBuf) {
         (root.join("no_claude"), root.join("no_codex"))
     }
 
-    // T-001 (FR-002): index_and_report_with embeds every pending chunk when a
-    // model loads. Given 3 directly-seeded un-embedded chunks and a MockEmbedder
-    // loader, after index the pending set (NOT EXISTS vec_chunks) is empty.
+    // T-001 (FR-002): embed_all_pending embeds every pending chunk when a model
+    // is present. Given 3 directly-seeded un-embedded chunks, the run embeds all
+    // 3 (vec_chunks gains 3 rows; the NOT EXISTS pending set empties). Calls
+    // embed_all_pending directly: the embed step is the unit under test, and
+    // index_from_dirs' orphan cleanup deletes hand-seeded sessions (no on-disk
+    // source), which would silently empty the pending set before embedding.
     // Perspective: equivalence (the "model present, pending > 0" class).
     #[test]
-    fn index_and_report_with_embeds_all_pending_chunks() {
-        let src = tempfile::TempDir::new().unwrap();
-        let (claude_dir, codex_dir) = absent_source_dirs(src.path());
-
+    fn embed_all_pending_embeds_every_pending_chunk() {
         let db_dir = tempfile::TempDir::new().unwrap();
         let db_path = db_dir.path().join("recall.db");
-        {
-            let conn = open_or_create_db(&db_path).unwrap();
+        let mut conn = open_or_create_db(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
+            [],
+        )
+        .unwrap();
+        for i in 1..=3 {
             conn.execute(
-                "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
-                [],
+                "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+                 VALUES (?1, 's1', ?2, 0)",
+                rusqlite::params![i, format!("pending content {i}")],
             )
             .unwrap();
-            for i in 1..=3 {
-                conn.execute(
-                    "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
-                     VALUES (?1, 's1', ?2, 0)",
-                    rusqlite::params![i, format!("pending content {i}")],
-                )
-                .unwrap();
-            }
         }
 
-        let opts = indexer::IndexOptions {
-            force: false,
-            claude_dir: &claude_dir,
-            codex_dir: &codex_dir,
-        };
-        index_and_report_with(&Some(db_path.clone()), &opts, mock_loader).unwrap();
+        let result = embed_all_pending(&mut conn, &embedder::MockEmbedder::new()).unwrap();
 
-        let conn = open_or_create_db(&db_path).unwrap();
+        assert_eq!(result.embedded, 3, "every pending chunk embeds");
+        assert_eq!(result.failed_count, 0, "a working embedder fails nothing");
+        assert_eq!(pending_embed_count(&conn), 0, "the pending set empties");
+        assert_eq!(vec_chunk_count(&conn), 3, "each chunk gains a vec row");
+    }
+
+    // T-010 (FR-002, FR-004): a partial embed failure flows through
+    // embed_all_pending — it tallies the failed batch, runs
+    // warn_if_batches_failed (the tracing-warn path), and stays Ok so the index
+    // is non-fatal. Given 3 pending chunks where 'x' poisons their single batch,
+    // the run reports embedded=0, failed_count=3, carries the first batch error
+    // for the --json note, and leaves the batch pending for the next run.
+    // Perspective: error (the failing-embedder arm) + state (EmbedResult tally).
+    #[test]
+    fn embed_all_pending_partial_failure_reports_failed_count() {
+        let db_dir = tempfile::TempDir::new().unwrap();
+        let db_path = db_dir.path().join("recall.db");
+        let mut conn = open_or_create_db(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+             VALUES (1, 's1', 'x', 0)",
+            [],
+        )
+        .unwrap();
+        for i in 2..=3 {
+            conn.execute(
+                "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+                 VALUES (?1, 's1', ?2, 0)",
+                rusqlite::params![i, format!("pending content {i}")],
+            )
+            .unwrap();
+        }
+
+        let result =
+            embed_all_pending(&mut conn, &embedder::MockEmbedder::failing_on_text("x")).unwrap();
+
+        assert_eq!(
+            result.embedded, 0,
+            "the poisoned single batch embeds nothing"
+        );
+        assert_eq!(
+            result.failed_count, 3,
+            "the whole 3-chunk batch is reported failed"
+        );
+        let err = result.first_error.as_deref().unwrap_or_default();
+        assert!(
+            err.contains("poison text"),
+            "the first batch error is carried up for the --json note, got: {err:?}"
+        );
         assert_eq!(
             pending_embed_count(&conn),
-            0,
-            "index with a loadable model must embed every pending chunk"
+            3,
+            "the failed batch stays pending for the next run"
         );
     }
 
-    // T-002 (FR-003): embedding is incremental — a second index re-embeds nothing.
-    // Given 1 already-embedded chunk and 1 new pending chunk, the first index
-    // embeds the new one; the second leaves the vec_chunks count unchanged (the
-    // NOT EXISTS gate skips both). Perspective: hazard (re-run idempotence) +
-    // boundary (the already-embedded vs pending split).
+    // T-002 (FR-003): embedding is incremental — a second run re-embeds nothing.
+    // Given 1 already-embedded chunk and 1 new pending chunk, the first
+    // embed_all_pending embeds exactly the pending one (vec 1→2); the second
+    // leaves the count unchanged (the NOT EXISTS gate skips both).
+    // Perspective: hazard (re-run idempotence) + boundary (the already-embedded
+    // vs pending split).
     #[test]
-    fn index_and_report_with_reembeds_nothing_on_second_run() {
-        let src = tempfile::TempDir::new().unwrap();
-        let (claude_dir, codex_dir) = absent_source_dirs(src.path());
-
+    fn embed_all_pending_reembeds_nothing_on_second_run() {
         let db_dir = tempfile::TempDir::new().unwrap();
         let db_path = db_dir.path().join("recall.db");
-        {
-            let conn = open_or_create_db(&db_path).unwrap();
+        let mut conn = open_or_create_db(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
+            [],
+        )
+        .unwrap();
+        // chunk 1 pre-embedded, chunk 2 pending.
+        for (id, content) in [(1, "already embedded"), (2, "new pending")] {
             conn.execute(
-                "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
-                [],
-            )
-            .unwrap();
-            // chunk 1 pre-embedded, chunk 2 pending.
-            for (id, content) in [(1, "already embedded"), (2, "new pending")] {
-                conn.execute(
-                    "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
-                     VALUES (?1, 's1', ?2, 0)",
-                    rusqlite::params![id, content],
-                )
-                .unwrap();
-            }
-            let emb = embedder::MockEmbedder::deterministic_vector("already embedded");
-            conn.execute(
-                "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, 1, 0)",
-                [embedder::f32_as_bytes(&emb)],
+                "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+                 VALUES (?1, 's1', ?2, 0)",
+                rusqlite::params![id, content],
             )
             .unwrap();
         }
+        let emb = embedder::MockEmbedder::deterministic_vector("already embedded");
+        conn.execute(
+            "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, 1, 0)",
+            [embedder::f32_as_bytes(&emb)],
+        )
+        .unwrap();
 
-        let opts = indexer::IndexOptions {
-            force: false,
-            claude_dir: &claude_dir,
-            codex_dir: &codex_dir,
-        };
-        index_and_report_with(&Some(db_path.clone()), &opts, mock_loader).unwrap();
-
-        let after_first = {
-            let conn = open_or_create_db(&db_path).unwrap();
-            assert_eq!(
-                pending_embed_count(&conn),
-                0,
-                "first index must embed the one new pending chunk"
-            );
-            vec_chunk_count(&conn)
-        };
-
-        index_and_report_with(&Some(db_path.clone()), &opts, mock_loader).unwrap();
-
-        let after_second = {
-            let conn = open_or_create_db(&db_path).unwrap();
-            vec_chunk_count(&conn)
-        };
+        let first = embed_all_pending(&mut conn, &embedder::MockEmbedder::new()).unwrap();
         assert_eq!(
-            after_second, after_first,
-            "a second index must re-embed nothing (NOT EXISTS vec_chunks gate)"
+            first.embedded, 1,
+            "the first run embeds only the pending chunk"
+        );
+        assert_eq!(vec_chunk_count(&conn), 2, "vec gains exactly the new chunk");
+
+        let second = embed_all_pending(&mut conn, &embedder::MockEmbedder::new()).unwrap();
+        assert_eq!(second.embedded, 0, "the second run re-embeds nothing");
+        assert_eq!(
+            vec_chunk_count(&conn),
+            2,
+            "a second run must re-embed nothing (NOT EXISTS vec_chunks gate)"
         );
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -428,6 +428,33 @@ fn index_json_emits_structured_embed_summary() {
     );
 }
 
+// T-CLI027: `rebuild --json` mirrors the index envelope contract through the
+// rebuild dispatch arm (run_rebuild → index_command_output). On an empty index
+// the wipe-and-rebuild embeds nothing and fails nothing, so the counts are a
+// deterministic 0/0 regardless of model presence, and the exit is 0.
+#[test]
+fn rebuild_json_emits_structured_embed_summary() {
+    let dir = TempDir::new().unwrap();
+    let out = recall(dir.path())
+        .args(["rebuild", "--json"])
+        .output()
+        .expect("spawn recall binary");
+    assert_eq!(out.status.code(), Some(0), "rebuild --json should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout should be one JSON envelope, got {stdout:?}: {e}"));
+    assert_eq!(
+        v["data"]["embedded"],
+        serde_json::json!(0),
+        "an empty rebuild embeds nothing, got: {stdout}"
+    );
+    assert_eq!(
+        v["data"]["failed_count"],
+        serde_json::json!(0),
+        "an empty rebuild has no embed failures, got: {stdout}"
+    );
+}
+
 // T-CLI019: `status --json` against a never-created index reports zero counters
 // with model_ready:false as a success envelope, exit 0 — the no-database branch
 // of run_status. Pairs with T-CLI013, which runs `index` first (the live path).

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -398,13 +398,15 @@ fn show_without_json_keeps_human_output() {
     );
 }
 
-// T-CLI018: a side-effect command (`index`) with `--json` emits the no_payload
-// envelope — data:null, degraded:false, empty notes — and exits 0. Pins the
-// machine contract for commands that produce no result payload (the only source
-// of `data:null` in the envelope). Progress spinners go to stderr, so stdout is
-// exactly the one envelope; parsed as JSON, not substring-matched.
+// T-CLI018 (#130 D2/FR-008): `index --json` emits a structured embed summary —
+// `data` carries `{ embedded, failed_count }` (no longer null) so an agent reads
+// how much embedding happened, and exits 0. An empty index embeds nothing and
+// fails nothing regardless of whether the model is present, so the counts are a
+// deterministic 0/0; the degraded flag and notes depend on model presence and are
+// covered deterministically by the `index_command_output` unit tests (T-003..006).
+// Progress spinners go to stderr, so stdout is exactly the one envelope.
 #[test]
-fn index_json_emits_null_data_envelope() {
+fn index_json_emits_structured_embed_summary() {
     let dir = TempDir::new().unwrap();
     let out = recall(dir.path())
         .args(["index", "--json"])
@@ -414,19 +416,15 @@ fn index_json_emits_null_data_envelope() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     let v: serde_json::Value = serde_json::from_str(stdout.trim())
         .unwrap_or_else(|e| panic!("stdout should be one JSON envelope, got {stdout:?}: {e}"));
-    assert!(
-        v["data"].is_null(),
-        "a side-effect command must emit data:null, got: {stdout}"
+    assert_eq!(
+        v["data"]["embedded"],
+        serde_json::json!(0),
+        "an empty index embeds nothing, got: {stdout}"
     );
     assert_eq!(
-        v["degraded"],
-        serde_json::json!(false),
-        "index is not a degraded path, got: {stdout}"
-    );
-    assert_eq!(
-        v["notes"],
-        serde_json::json!([]),
-        "index carries no notes, got: {stdout}"
+        v["data"]["failed_count"],
+        serde_json::json!(0),
+        "an empty index has no embed failures, got: {stdout}"
     );
 }
 


### PR DESCRIPTION
## 概要と背景

`recall index` の embed が batch 失敗で停止しなくなり、部分失敗が `--json` で観測可能になる (#130 D1/D2)。従来は最初の失敗 batch で `break` するうえ chunk を text 長昇順で処理するため、決定論的に失敗する最短 poison chunk が毎回 batch 1 に入り、それ以降の backlog が永久に embed されなかった。さらに `--json` は data:null / degraded:false を返すため、agent が部分失敗を検知できなかった。

## 変更内容

- `embed_chunks` (src/embedder.rs): batch 失敗時の `break` を除去し次 batch へ継続。失敗 batch は tx 未 commit なので chunk は pending に残り、次回 `recall index` の NOT EXISTS ゲートが再試行する。`EmbedResult` は `{ embedded, failed_count, first_error }` を報告
- `index_command_output` (src/main.rs): 純粋関数を新設し、model-less load と embed batch 停止の両 degradation を `--json` の degraded:true + notes に surface。payload は `{ embedded, failed_count }` で magnitude を運ぶ。degraded ⟺ notes 非空 (search と同型)
- `index --json` の data 契約変更: 従来の null → `{ embedded, failed_count }` (T-CLI018 更新)
- note の first_error は control char strip + 120 chars cap (他の envelope 文字列と同じ扱い)
- `MockEmbedder` に `embed_documents_batch` を明示実装 — production の dispatch 先。依存していた rurico trait default は rurico HEAD で削除済みのため、pin 更新で壊れる前に自前実装へ
- `warn_if_stopped` → `warn_if_batches_failed` に rename (continue 化で「停止」しなくなったため)
- /audit (10 reviewers → challenge → verify → integrate) 実施。confirmed P0/P1 = 0、medium 指摘 (mock seam・テスト網羅) は本 PR に反映済み

## スコープ

- **含まないもの**: poison chunk の隔離・永続化 (transient/deterministic の区別、#130 A2 slice)、IndexOutcome の enum 化、human 端末向け表示強化 (OUTCOME non-goal)。いずれも #130 の別スライス

## 設計判断

- 失敗の非永続化 (A1): 失敗 chunk に印を付けず pending に残す。EmbedError から transient/deterministic を判別できないため、隔離 (A2) は誤検知リスクごと別スライスへ
- degraded ≠ failure: exit code は write 成功のみで決まり 0 のまま (search と整合)。失敗は --json の degraded + notes で表現
- note は human 向け文、magnitude は data.failed_count (machine channel) — 数値を prose に混ぜない

## テスト方法

1. `cargo nextest run` → 229 tests green (T-001..T-009)
2. T-001/T-002: poison batch が次 batch を block しない + pending 維持
3. T-008: 2回目の run が失敗 batch を embed (retry idempotency)
4. T-003/T-009: --json envelope の degraded/notes/payload + note の sanitize

## 関連

- Refs #130 (D1/D2 スライス。残り D3/D5/D6 + A2 は別 PR)
