### PR TITLE
rusqlite 0.40 と MSRV 1.96 へ fleet 追従（rurico/amici rev bump 同時）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=b545722#b54572260e8a7685c7503284de27eec0585dfd28"
+source = "git+https://github.com/thkt/amici?rev=5f4ee12#5f4ee1211655d09d31495c7b70534c02224679a0"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bumpalo"
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "mach-sys"
@@ -2032,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
+source = "git+https://github.com/thkt/rurico?rev=adbe3a8#adbe3a8b7457dc8f174160b629b604479c6019cf"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
+source = "git+https://github.com/thkt/rurico?rev=adbe3a8#adbe3a8b7457dc8f174160b629b604479c6019cf"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2059,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -2785,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -3326,9 +3326,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "recall"
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 description = "Full-text search CLI for past Claude Code and Codex sessions"
 license = "MIT"
 repository = "https://github.com/thkt/recall"
@@ -11,13 +11,13 @@ repository = "https://github.com/thkt/recall"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "b545722" }
+amici = { git = "https://github.com/thkt/amici", rev = "5f4ee12" }
 anyhow = "1.0.102"
 bytemuck = "1"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 dirs = "6.0.0"
-rurico = { git = "https://github.com/thkt/rurico", rev = "a573655" }
-rusqlite = { version = "0.39.0", features = ["bundled"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "adbe3a8" }
+rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 thiserror = "2"
@@ -25,8 +25,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "b545722", features = ["test-support"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "a573655", features = ["test-support"] }
+amici = { git = "https://github.com/thkt/amici", rev = "5f4ee12", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "adbe3a8", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -77,7 +77,7 @@ fn embed_chunks(
                     rusqlite::params_from_iter(batch_ids.iter()),
                 )?;
                 for (chunked, &i) in embeddings.iter().zip(batch_idx) {
-                    for (sub_idx, sub_emb) in chunked.chunks.iter().enumerate() {
+                    for (sub_idx, sub_emb) in chunked.chunks().iter().enumerate() {
                         let embedding_bytes = f32_as_bytes(sub_emb);
                         tx.execute(
                             "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) \
@@ -190,6 +190,16 @@ impl MockEmbedder {
         }
     }
 
+    /// Constructs the error inline: rurico's `EmbedError::inference` helpers are
+    /// `pub(crate)`, and the enum's `#[non_exhaustive]` does not block downstream
+    /// construction of existing variants.
+    fn inference_error(message: String) -> EmbedError {
+        EmbedError::Inference {
+            message,
+            source: None,
+        }
+    }
+
     pub(crate) fn deterministic_vector(text: &str) -> Vec<f32> {
         let dims = EMBEDDING_DIMS;
         let mut v = vec![0.0f32; dims];
@@ -212,7 +222,7 @@ impl Embed for MockEmbedder {
         if let Some(limit) = self.fail_after {
             let count = self.call_count.fetch_add(1, Ordering::SeqCst);
             if count >= limit {
-                return Err(EmbedError::Inference("mock failure".to_owned()));
+                return Err(Self::inference_error("mock failure".to_owned()));
             }
         }
         Ok(Self::deterministic_vector(text))
@@ -222,12 +232,12 @@ impl Embed for MockEmbedder {
         if let Some(limit) = self.fail_after {
             let count = self.call_count.fetch_add(1, Ordering::SeqCst);
             if count >= limit {
-                return Err(EmbedError::Inference("mock failure".to_owned()));
+                return Err(Self::inference_error("mock failure".to_owned()));
             }
         }
-        Ok(ChunkedEmbedding::new(vec![Self::deterministic_vector(
-            text,
-        )]))
+        Ok(ChunkedEmbedding::try_new(vec![
+            Self::deterministic_vector(text),
+        ])?)
     }
 
     /// Explicit impl of the production dispatch target: `embed_chunks` calls this
@@ -238,7 +248,7 @@ impl Embed for MockEmbedder {
         if let Some(poison) = self.fail_on_text.as_deref()
             && texts.contains(&poison)
         {
-            return Err(EmbedError::Inference(format!("poison text: {poison}")));
+            return Err(Self::inference_error(format!("poison text: {poison}")));
         }
         texts.iter().map(|t| self.embed_document(t)).collect()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -300,7 +300,7 @@ mod tests {
             ErrorCode::TempFailure
         );
         assert_eq!(
-            download_error(&ModelDownloadError::ProbeFailed("corrupt".into())).error_code(),
+            download_error(&ModelDownloadError::ProbeFailed(Some("corrupt".into()))).error_code(),
             ErrorCode::TempFailure
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use amici::cli::exit_code::codes;
 use amici::cli::{Spinner, done, exit_error, info as cli_info, try_expand_shorthand};
 use amici::logging::init_subscriber;
 use amici::model::embedder::{DegradedReason, try_load_embedder_default_logging};
-use amici::model::{degraded_reason_user_note, download_and_verify_model, record_degraded};
+use amici::model::{EmbedderDegraded, download_and_verify_model, record_degraded};
 use amici::storage::{collect_rows, filter::escape_like};
 use anyhow::{Context, Error, Result};
 use clap::error::ErrorKind as ClapErrorKind;
@@ -61,7 +61,7 @@ struct Cli {
     json: bool,
 }
 
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 enum Command {
     /// Parse and chunk new session logs (incremental). No model calls.
     Index,
@@ -127,7 +127,7 @@ enum Command {
     Status,
 }
 
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 enum ModelCommand {
     /// Download the embedding model and verify it loads.
     Download,
@@ -220,7 +220,9 @@ where
 
 /// The human-facing stderr note for a degraded embedder load (`note: ...`).
 fn search_degraded_note(reason: DegradedReason) -> Option<String> {
-    degraded_reason_user_note(reason, "recall model download").map(|note| format!("note: {note}."))
+    EmbedderDegraded(reason)
+        .user_note("recall model download")
+        .map(|note| format!("note: {note}."))
 }
 
 /// The `--json` `notes[]` entry for a search that fell back to FTS-only, derived
@@ -231,7 +233,8 @@ fn search_degraded_note(reason: DegradedReason) -> Option<String> {
 /// list means no degradation note applies (a caller-disabled model), so the
 /// caller's `degraded` flag co-varies with it.
 fn search_fallback_notes(reason: DegradedReason) -> Vec<String> {
-    degraded_reason_user_note(reason, "recall model download")
+    EmbedderDegraded(reason)
+        .user_note("recall model download")
         .map(|note| vec![format!("semantic search unavailable: {note}")])
         .unwrap_or_default()
 }
@@ -704,7 +707,7 @@ fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<CommandOutput>
     let chunks: i64 = conn.query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))?;
     let embedded: i64 = conn.query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))?;
 
-    let model_ok = cached_artifacts(ModelId::default())
+    let model_ok = cached_artifacts(ModelId::DEFAULT)
         .map(|opt| opt.is_some())
         .unwrap_or(false);
 
@@ -1080,6 +1083,7 @@ fn main() -> ExitCode {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::fs;
 
     use super::*;
@@ -1430,14 +1434,14 @@ mod tests {
     #[test]
     fn test_rebuild_is_a_distinct_subcommand() {
         let cli = Cli::try_parse_from(["recall", "rebuild"]).unwrap();
-        assert!(matches!(cli.command, Some(Command::Rebuild)));
+        assert_matches!(cli.command, Some(Command::Rebuild));
     }
 
     #[test]
     fn test_index_no_longer_accepts_force_flag() {
         assert!(Cli::try_parse_from(["recall", "index", "--force"]).is_err());
         let cli = Cli::try_parse_from(["recall", "index"]).unwrap();
-        assert!(matches!(cli.command, Some(Command::Index)));
+        assert_matches!(cli.command, Some(Command::Index));
     }
 
     #[test]


### PR DESCRIPTION
## 概要と背景

recall だけが fleet (rurico/amici) の rusqlite 0.40 + MSRV 1.96 整列から取り残されていた (rusqlite 0.39 / MSRV 1.95 / rurico `a573655` / amici `b545722`)。libsqlite3-sys の `links = "sqlite3"` は 0.37/0.38 の共存を禁じるため、rurico/amici の rev bump と自前 rusqlite の 0.40 化は同一変更でしか成立しない (#132)。#129 (MSRV 1.96 + `assert_matches!`) も本文で「次の機能変更マージに合流」としていたため、1 PR に束ねた。

## 変更内容

- rurico `a573655` → `adbe3a8`、amici `b545722` → `5f4ee12` (dep + dev-dep)
- rusqlite 0.39 → 0.40 (bundled SQLite 3.53.1)、libsqlite3-sys 0.38.0 へ単一解決 (0.37 削除)
- rust-version 1.95 → 1.96、`assert!(matches!(...))` ×2 を `assert_matches!` 化 (`Command`/`ModelCommand` に失敗時表示用の `Debug` derive)
- rurico embedding API contracts (thkt/rurico#205) 追従:
  - `ChunkedEmbedding::try_new` + `chunks()` アクセサ (field の private 化に対応)
  - `EmbedError::Inference` の struct variant 化 — rurico の constructor helper は `pub(crate)` のため inline 構築 (`#[non_exhaustive]` は既存 variant の downstream 構築を妨げない)
  - `ModelId::DEFAULT` (`Default` derive 削除に対応)
- amici model API (thkt/amici#122) 追従:
  - `EmbedderDegraded(reason).user_note()` (旧 `degraded_reason_user_note`)
  - `ModelDownloadError::ProbeFailed(Option<String>)`

## 設計判断

- MockEmbedder のエラー構築は `inference_error` ヘルパに集約 (3箇所が同一の構築知識を共有するため)。
- `Embed::embed_documents_batch` の required 化は PR #134 の明示 override が先回り済みで、追加変更なし。

## テスト方法

- `cargo nextest run --all-features`: 231 passed
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --check`: clean
- `cargo tree -i libsqlite3-sys` → 0.38.0 単一 / `cargo tree -i rurico` → `adbe3a8` 単一 rev (amici 経由と一致 = `Arc<dyn Embed>` の trait object が整合)
- VTab API (0.40 唯一の breaking) は未使用 (SQL 文字列内の `VIRTUAL TABLE` 文のみ)
- `cargo-deny check`: advisories / bans / licenses / sources ok
- CI coverage gate のローカル再現: `cargo llvm-cov --lcov` → cfg(test) フィルタ → `diff-cover --compare-branch=origin/main --fail-under=95` → **100%** (変更 7 行 / Missing 0)

## 関連

- Closes #132
- Closes #129
