### PR TITLE
version を 0.8.0 へ bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "recall"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "amici",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recall"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.96"
 description = "Full-text search CLI for past Claude Code and Codex sessions"


### PR DESCRIPTION
## 概要と背景

v0.7.0 (2026-03-25、commit `44fe726`) 以降の main には未リリースの変更が蓄積している: `--json` envelope + sysexits exit code (#67/#82)、index=embed 統合と `recall embed` subcommand / `--no-embed` の廃止 (#73、BREAKING)、embed 失敗の non-blocking 化 + `--json` 表面化 (#130 D1/D2)、fleet 整列 (rusqlite 0.40 / MSRV 1.96 / rurico `adbe3a8`、#132/#129)。BREAKING を含むため 0.x 慣例で minor bump し v0.8.0 とする。

なお v0.7.0 の release workflow は failure で終わっており (run 23535925950)、brew tap formula は 0.6.5 のまま。本リリースで formula も追い付く。

## 変更内容

- `Cargo.toml` / `Cargo.lock`: version 0.7.0 → 0.8.0

## テスト方法

- merge 後に `v0.8.0` tag を push → release workflow (aarch64 build + mlx.metallib 同梱 → GitHub Release → homebrew-tap formula 自動更新) の成功を確認
- `brew upgrade recall` で 0.8.0 が入ることを確認

## 関連

- 直近の機能 PR: #133 (index=embed 統合)、#134 (#130 D1/D2)、#135 (fleet 整列)
