### PR TITLE
release: update-homebrew の artifact パス想定を撤廃し find で発見

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,11 +135,22 @@ jobs:
             exit 1
           fi
 
+          # Locate the archive without assuming the extraction layout:
+          # upload-artifact v7 x download-artifact v8 changed it and broke the
+          # previous hard-coded artifacts/<name>/<name>.tar.gz path (v0.8.0,
+          # run 26935402876), while the release job's glob kept working.
+          ARCHIVE=$(find artifacts -name 'recall-aarch64-apple-darwin.tar.gz' -type f | head -1)
+          if [ -z "$ARCHIVE" ]; then
+            echo "::error::recall-aarch64-apple-darwin.tar.gz not found under artifacts/"
+            ls -R artifacts
+            exit 1
+          fi
+
           # Calculate checksum (Apple Silicon only; mlx backend requires Metal)
-          SHA_AARCH64_DARWIN=$(sha256sum artifacts/recall-aarch64-apple-darwin/recall-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)
+          SHA_AARCH64_DARWIN=$(sha256sum "$ARCHIVE" | cut -d' ' -f1)
 
           # Verify macOS archive contains mlx.metallib
-          tar tzf artifacts/recall-aarch64-apple-darwin/recall-aarch64-apple-darwin.tar.gz | grep -q mlx.metallib \
+          tar tzf "$ARCHIVE" | grep -q mlx.metallib \
             || { echo "::error::mlx.metallib missing from macOS archive"; exit 1; }
 
           # Generate Formula inline (self-contained; no tap-side template dependency)


### PR DESCRIPTION
## 概要と背景

v0.8.0 の release workflow (run [26935402876](https://github.com/thkt/recall/actions/runs/26935402876)) で update-homebrew job が失敗した。`sha256sum` / `tar` がハードコードパス `artifacts/recall-aarch64-apple-darwin/recall-aarch64-apple-darwin.tar.gz` を `No such file or directory` で開けず、annotation の「mlx.metallib missing from macOS archive」は tar 失敗の副次エラーで誤誘導 (実 asset には mlx.metallib が同梱されていることをローカルで `tar tzf` 検証済み)。

同 run の release job は glob (`artifacts/**/*`) で同一 artifact を発見し upload に成功している = ダウンロードは完了しており、**展開レイアウトだけが想定と異なる**。根因は upload-artifact v7 × download-artifact v8 の組み合わせによる展開構造の変化 (v8.0.0 は Content-Type 判定で解凍をスキップするようになった)。

## 変更内容

- update-homebrew のハードコードパスを `find artifacts -name 'recall-aarch64-apple-darwin.tar.gz'` での発見に置換 (レイアウト仮定を撤廃)
- 見つからない場合は `ls -R artifacts` で実構造をログに残して exit 1 (今回のような「副次エラーが真因を隠す」状況を防ぐ)

## テスト方法

- workflow の tag trigger は再現できないため、**検証は次回リリースの tag push 時のみ可能**
- v0.8.0 の formula は手動更新で復旧済み (homebrew-tap `85e8311`、Release asset から sha256 を実計算)

## 関連

- v0.7.0 の release failure (run 23535925950) は当時の Linux build (mlx-sys がビルド不可) が原因の別事象。matrix からは削除済み
