### PR TITLE
pending 探索を one-pass 差分にして embed 前の 40 分無音を解消

### DIFF
--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::result::Result as StdResult;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -8,7 +9,6 @@ use rurico::embed::Embed;
 #[cfg(test)]
 use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS, EmbedError};
 use rusqlite::Connection;
-use rusqlite::types::ToSql;
 use tracing::warn;
 
 #[derive(Default)]
@@ -40,7 +40,7 @@ pub(crate) fn f32_as_bytes(v: &[f32]) -> &[u8] {
     bytemuck::cast_slice(v)
 }
 
-fn embed_chunks(
+pub(crate) fn embed_chunks(
     conn: &mut Connection,
     embedder: &dyn Embed,
     chunks: &[(i64, String)],
@@ -64,7 +64,7 @@ fn embed_chunks(
             Ok(embeddings) => {
                 let tx = conn.transaction()?;
                 // Idempotent replay guard for stale concurrent work that reached
-                // this tx after the NOT EXISTS pending query. Batched into one
+                // this tx after the pending query. Batched into one
                 // IN-delete: vec0's +chunk_id is an unindexed auxiliary column, so
                 // each `DELETE WHERE chunk_id = ?` is a full O(N) scan (EXPLAIN
                 // reports "SCAN vec_chunks VIRTUAL TABLE") — per-chunk deletes were
@@ -96,7 +96,7 @@ fn embed_chunks(
                 // Skip the failed batch and keep going: a poison chunk fails its
                 // whole ≤128-batch (all-or-nothing) but must not block the rest of
                 // the backlog. The chunks stay pending (no tx committed here) for
-                // the next index to retry via the NOT EXISTS gate.
+                // the next index to retry via the pending gate.
                 failed_count += batch_idx.len();
                 if first_error.is_none() {
                     first_error = Some(format!("batch: {e}"));
@@ -112,45 +112,55 @@ fn embed_chunks(
     })
 }
 
-fn query_and_embed(
-    conn: &mut Connection,
-    embedder: &dyn Embed,
-    sql: &str,
-    params: &[&dyn ToSql],
-    on_progress: Option<&dyn Fn(usize, usize)>,
-) -> Result<EmbedResult> {
-    let missing: Vec<(i64, String)> = {
-        let mut stmt = conn.prepare(sql)?;
-        let rows = stmt.query_map(params, |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-        })?;
-        rows.collect::<StdResult<Vec<_>, _>>()?
+/// Collect up to `budget` chunks that have no `vec_chunks` row, newest first.
+///
+/// One pass over each table (#138): the previous correlated `NOT EXISTS` form
+/// re-scanned vec_chunks per qa_chunks row — its `+chunk_id` is an unindexed
+/// auxiliary column (see the DELETE note in `embed_chunks`), so at 38k chunks
+/// that was O(N×M) ≈ 15-20 minutes of silence before the first batch.
+pub(crate) fn pending_chunks(conn: &Connection, budget: usize) -> Result<Vec<(i64, String)>> {
+    if budget == 0 {
+        return Ok(Vec::new());
+    }
+
+    let embedded: HashSet<i64> = {
+        let mut stmt = conn.prepare("SELECT DISTINCT chunk_id FROM vec_chunks")?;
+        let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+        rows.collect::<StdResult<_, _>>()?
     };
 
-    embed_chunks(conn, embedder, &missing, on_progress)
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.content FROM qa_chunks c \
+         ORDER BY c.timestamp DESC NULLS LAST",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        let id: i64 = row.get(0)?;
+        if embedded.contains(&id) {
+            // Skip without decoding content; sqlite materializes only the
+            // columns a row actually reads.
+            return Ok(None);
+        }
+        Ok(Some((id, row.get::<_, String>(1)?)))
+    })?;
+    let missing: Vec<(i64, String)> = rows
+        .filter_map(StdResult::transpose)
+        .take(budget)
+        .collect::<StdResult<_, _>>()?;
+    Ok(missing)
 }
 
+/// Test-only composition of the production pair (`pending_chunks` →
+/// `embed_chunks`); `embed_all_pending` (main.rs) calls the pair directly so
+/// the empty-pending case can skip the Spinner.
+#[cfg(test)]
 pub(crate) fn embed_recent_chunks(
     conn: &mut Connection,
     embedder: &dyn Embed,
     budget: usize,
     on_progress: Option<&dyn Fn(usize, usize)>,
 ) -> Result<EmbedResult> {
-    if budget == 0 {
-        return Ok(EmbedResult::default());
-    }
-
-    let budget_i64 = budget as i64;
-    query_and_embed(
-        conn,
-        embedder,
-        "SELECT c.id, c.content FROM qa_chunks c \
-         WHERE NOT EXISTS (SELECT 1 FROM vec_chunks v WHERE v.chunk_id = c.id) \
-         ORDER BY c.timestamp DESC NULLS LAST \
-         LIMIT ?",
-        &[&budget_i64 as &dyn ToSql],
-        on_progress,
-    )
+    let missing = pending_chunks(conn, budget)?;
+    embed_chunks(conn, embedder, &missing, on_progress)
 }
 
 /// Returns deterministic 768-dim vectors derived from text bytes.
@@ -550,5 +560,40 @@ mod tests {
             )
             .unwrap();
         assert_eq!(pending, 0, "no chunk is left behind after the retry");
+    }
+
+    // #138: budget truncation must keep the newest chunks. With 3 pending chunks
+    // at distinct timestamps and budget 1, the embedded row is the one with the
+    // newest timestamp (ORDER BY timestamp DESC NULLS LAST). Pins the selection
+    // order across the one-pass rewrite of the pending query.
+    // Perspective: boundary (budget < pending).
+    #[test]
+    fn test_embed_recent_chunks_budget_prefers_newest_chunk() {
+        let (_dir, mut conn) = setup_test_db();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f', '/p', 'slug', 0, 0.0, NULL)",
+            [],
+        )
+        .unwrap();
+        for (id, ts) in [(1_i64, 100_i64), (2, 300), (3, 200)] {
+            conn.execute(
+                "INSERT INTO qa_chunks (id, session_id, content, timestamp) \
+                 VALUES (?1, 's1', ?2, ?3)",
+                rusqlite::params![id, format!("content_{id}"), ts],
+            )
+            .unwrap();
+        }
+
+        let embedder = MockEmbedder::new();
+        let result = embed_recent_chunks(&mut conn, &embedder, 1, None).unwrap();
+
+        assert_eq!(result.embedded, 1, "budget 1 embeds exactly one chunk");
+        let embedded_id: i64 = conn
+            .query_row("SELECT chunk_id FROM vec_chunks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            embedded_id, 2,
+            "budget 1 must pick the chunk with the newest timestamp (ts=300)"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -402,31 +402,27 @@ where
     }
 }
 
-/// Embed every chunk absent from `vec_chunks`. Incremental by the `NOT EXISTS`
-/// gate inside `embed_recent_chunks`, so a re-index embeds only new chunks; a
-/// `rebuild` re-embeds all because its `force` DELETE cleared `vec_chunks` first.
+/// Embed every chunk absent from `vec_chunks`. Incremental by the one-pass
+/// pending gate (`embedder::pending_chunks`), so a re-index embeds only new
+/// chunks; a `rebuild` re-embeds all because its `force` DELETE cleared
+/// `vec_chunks` first. The pending list is collected once and fed straight to
+/// `embed_chunks` — a separate COUNT would re-scan vec_chunks (#138).
 fn embed_all_pending(conn: &mut Connection, embedder: &dyn Embed) -> Result<embedder::EmbedResult> {
-    let pending: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM qa_chunks c \
-         WHERE NOT EXISTS (SELECT 1 FROM vec_chunks v WHERE v.chunk_id = c.id)",
-        [],
-        |r| r.get(0),
-    )?;
-    if pending == 0 {
+    let pending = embedder::pending_chunks(conn, usize::MAX)?;
+    if pending.is_empty() {
         return Ok(embedder::EmbedResult::default());
     }
-    let pending_usize = usize::try_from(pending).expect("chunk count fits in usize");
     let sp = Spinner::new("Embedding chunks...");
-    let result = embedder::embed_recent_chunks(
+    let result = embedder::embed_chunks(
         conn,
         embedder,
-        pending_usize,
+        &pending,
         Some(&|done, total| sp.set_message(&format!("Embedding chunks... {done}/{total}"))),
     )?;
     sp.finish(&format!("Embedded {} chunks", result.embedded));
     // A mid-run batch failure is non-fatal: chunks already embedded are committed,
     // the rest stay pending, and the FTS index is complete and queryable. The next
-    // `recall index` retries the remaining pending via the NOT EXISTS gate, so we
+    // `recall index` retries the remaining pending via the pending gate, so we
     // warn rather than fail. The stop is also surfaced in the index `--json`
     // envelope via `failed_count` (index_command_output).
     result.warn_if_batches_failed();


### PR DESCRIPTION
## 概要と背景

v0.8.0 の `recall index` が embed 開始前に **CPU 100% で 40 分以上無音**になる (#138)。pending 探索の相関 `NOT EXISTS` が qa_chunks 各行ごとに vec_chunks の full scan を誘発していた — vec0 の `+chunk_id` は unindexed auxiliary column (#127 RC-1 で確定済み) のため O(N×M) で、`embed_all_pending` は COUNT → SELECT で**これを 2 周**していた。38k chunks の実 DB で初めて顕在化した scale バグ (テスト DB では検出不能)。

## 変更内容

- `embedder::pending_chunks` 新設: `SELECT DISTINCT chunk_id FROM vec_chunks` を **1 回だけ** scan して HashSet 化し、qa_chunks を timestamp DESC で歩いて未 embed 行のみ `take(budget)` 件収集 (O(N+M))
- `embed_all_pending` は収集済みリストを直接 `embed_chunks` へ渡す — 先行 COUNT を廃止し、vec_chunks の scan は **run 全体で 1 回**に
- `embed_recent_chunks` は production から呼ばれなくなり、`pending_chunks` → `embed_chunks` の test-only 合成として `#[cfg(test)]` 化
- pin テスト追加: budget 打ち切りが timestamp の新しい chunk を優先することを固定 (one-pass 化の等価性 pin)

## 設計判断

- **derived-table LEFT JOIN 案は不採用**: `EXPLAIN QUERY PLAN` で `MATERIALIZE v` (scan 1 回化) は得られるが `SCAN v LEFT-JOIN` — vtab 由来の materialized temp に automatic index が張られず、依然 O(N×M)。HashSet 差分は query planner 非依存で決定論的に O(N+M)
- 等価性: `NOT EXISTS (v.chunk_id = c.id)` ⟺ `c.id ∉ DISTINCT chunk_id`。`embed_chunks` は chunk の全 sub_idx を batch tx で atomic に commit するため「1 vec row でもあれば完全 embed 済み」が成立し membership 判定は安全

## テスト方法

- `cargo nextest run --all-features`: 232 passed (pin テスト含む)
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --check`: clean
- diff-cover (CI gate ローカル再現): **96%** (gate 95%、Missing 1 行は `prepare(...)?` の error edge)
- **実 DB (38k chunks) 実測**: 旧版は 40 分走っても embed 未到達 (pending scan 2 周に閉じ込め)。fix 版は**数分で embed 到達**し最初の batch 群 (+384) が commit、その後も継続的に進行 (GPU 推論がボトルネックになる正常状態へ)

## 関連

- Closes #138
- #127 (RC-1): vec0 aux column への per-chunk DELETE の batch IN 化。本 PR はその SELECT 版
- 非 TTY での進捗不可視性 (40 分無音が hang と区別不能) は #130 F21 の実害例として別途扱う
