### PR TITLE
version を 0.8.1 へ bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "recall"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "amici",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recall"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.96"
 description = "Full-text search CLI for past Claude Code and Codex sessions"


### PR DESCRIPTION
## 概要と背景

#138 fix (PR #139、pending 探索の one-pass 化) を brew 配布に届ける patch release。現行 brew 0.8.0 は SessionEnd hook の `recall index` ごとに O(N×M) の pending scan (38k chunks で 40 分級の CPU 浪費) を実行し続けるため、早期の配布が必要。

release workflow の実行は #137 (update-homebrew の artifact パス修正) の実検証を兼ねる — tag push でのみ検証可能な修正。

## 変更内容

- `Cargo.toml` / `Cargo.lock`: version 0.8.0 → 0.8.1

## テスト方法

- merge 後に `v0.8.1` tag を push → release workflow の **update-homebrew まで**の完走を確認 (前回 v0.8.0 はここで失敗し手動復旧)
- `brew upgrade recall` で 0.8.1 が入ることを確認

## 関連

- PR #139 (#138 fix)、PR #137 (release.yml 修正)