### PR TITLE
並行 hook の index 喪失を解消し D5/D6/TC-003/004 をテストで固定（#130 スライス）

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -12,7 +12,11 @@ const FTS_TOKENIZER: &str = "trigram";
 pub fn open_db(path: &Path) -> Result<Connection> {
     ensure_sqlite_vec().map_err(|e| anyhow::anyhow!(e))?;
     let mut conn = Connection::open(path)?;
-    conn.busy_timeout(Duration::from_secs(5))?;
+    // 30s, not 5s: the FTS index pass holds one write tx for 3-12s on a full
+    // tree (#130 D3, measured at 38k chunks), so concurrent SessionEnd hooks
+    // lost their run to SQLITE_BUSY at 5s. 30s absorbs the longest observed
+    // window; hooks run in the background, so the wait is invisible.
+    conn.busy_timeout(Duration::from_secs(30))?;
     let _: String = conn.query_row("PRAGMA journal_mode=WAL", [], |r| r.get(0))?;
     conn.execute_batch("PRAGMA synchronous=NORMAL;")?;
     create_schema(&mut conn)?;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -505,6 +505,8 @@ pub(crate) fn index_chunks(conn: &mut Connection) -> Result<ChunkStats> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, SystemTime};
+
     use super::*;
     use crate::db::setup_test_db;
     use crate::embedder::{EMBED_BATCH_SIZE, MockEmbedder, embed_recent_chunks};
@@ -547,6 +549,131 @@ mod tests {
         .unwrap();
         assert_eq!(stats2.indexed, 0);
         assert_eq!(stats2.total_sessions, 1);
+    }
+
+    // TC-003 (#130): the production steady state is a hook re-indexing an
+    // already-indexed tree. Beyond `indexed == 0` (parse skip, pinned above),
+    // the DB content must be byte-stable: no duplicate chunks, no FTS growth,
+    // no re-created sessions.
+    #[test]
+    fn test_index_from_dirs_steady_state_keeps_db_stable() {
+        let (_dir, mut conn) = setup_test_db();
+        let tmp = TempDir::new().unwrap();
+        let claude_dir = tmp.path().join("claude_projects");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(
+            claude_dir.join("s.jsonl"),
+            concat!(
+                r#"{"type":"user","cwd":"/proj","message":{"role":"user","content":"steady question"},"timestamp":"2026-03-01T00:00:00Z"}"#,
+                "\n",
+                r#"{"type":"assistant","cwd":"/proj","message":{"role":"assistant","content":"steady answer"},"timestamp":"2026-03-01T00:00:01Z"}"#,
+            ),
+        )
+        .unwrap();
+        let codex_dir = tmp.path().join("codex_sessions");
+        let opts = IndexOptions {
+            force: false,
+            claude_dir: &claude_dir,
+            codex_dir: &codex_dir,
+        };
+
+        index_from_dirs(&mut conn, &opts).unwrap();
+        index_chunks(&mut conn).unwrap();
+        let counts = |conn: &Connection| -> (i64, i64, i64, i64) {
+            let m = conn
+                .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+                .unwrap();
+            let c = conn
+                .query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))
+                .unwrap();
+            let s = conn
+                .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+                .unwrap();
+            let v = conn
+                .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
+                .unwrap();
+            (m, c, s, v)
+        };
+        let before = counts(&conn);
+
+        let stats = index_from_dirs(&mut conn, &opts).unwrap();
+        index_chunks(&mut conn).unwrap();
+
+        assert_eq!(stats.indexed, 0, "an unchanged tree re-parses nothing");
+        assert_eq!(
+            counts(&conn),
+            before,
+            "re-index of an unchanged tree must not grow or rewrite the DB"
+        );
+    }
+
+    // TC-004 (#130): mtime-forward re-index is the self-heal core — a session
+    // file appended after indexing (the tail of a live session) must be
+    // re-parsed, surface the new message, and replace its chunks without
+    // duplicating the session.
+    #[test]
+    fn test_index_from_dirs_reindexes_appended_file() {
+        let (_dir, mut conn) = setup_test_db();
+        let tmp = TempDir::new().unwrap();
+        let claude_dir = tmp.path().join("claude_projects");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let file = claude_dir.join("s.jsonl");
+        fs::write(
+            &file,
+            concat!(
+                r#"{"type":"user","cwd":"/proj","message":{"role":"user","content":"first question"},"timestamp":"2026-03-01T00:00:00Z"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let codex_dir = tmp.path().join("codex_sessions");
+        let opts = IndexOptions {
+            force: false,
+            claude_dir: &claude_dir,
+            codex_dir: &codex_dir,
+        };
+        index_from_dirs(&mut conn, &opts).unwrap();
+
+        // Append a turn and push mtime clearly past the 0.001s freshness epsilon.
+        let mut all = fs::read_to_string(&file).unwrap();
+        all.push_str(
+            r#"{"type":"assistant","cwd":"/proj","message":{"role":"assistant","content":"appended answer"},"timestamp":"2026-03-01T00:00:01Z"}"#,
+        );
+        fs::write(&file, all).unwrap();
+        let f = fs::OpenOptions::new().append(true).open(&file).unwrap();
+        f.set_modified(SystemTime::now() + Duration::from_secs(10))
+            .unwrap();
+        drop(f);
+
+        let stats = index_from_dirs(&mut conn, &opts).unwrap();
+
+        assert_eq!(stats.indexed, 1, "the appended file must be re-parsed");
+        let sessions: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            sessions, 1,
+            "re-index upserts the session, not duplicates it"
+        );
+        let appended: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE messages MATCH 'appended answer'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(appended, 1, "the appended message must be searchable");
+        let original: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE messages MATCH 'first question'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            original, 1,
+            "re-parsing the appended file must keep the original message searchable"
+        );
     }
 
     fn index_one_claude_session(content: &str) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2078,6 +2078,93 @@ mod tests {
         );
     }
 
+    // D5 (#130): the index context was only tested with NotInstalled; pin the
+    // other loader-failure variants. BackendUnavailable and ProbeFailed share
+    // one equivalence class (amici's user_note renders both as "unavailable",
+    // re-downloading would not help), so both must carry that note and skip
+    // embedding. The `record_degraded` half of D5 is covered by the loader's
+    // own test (try_load_embedder_cached_records_degraded_non_install_failure);
+    // production wires that loader in via index_and_report.
+    #[test]
+    fn index_and_report_with_unavailable_loader_carries_unavailability_note() {
+        for reason in [
+            DegradedReason::BackendUnavailable,
+            DegradedReason::ProbeFailed,
+        ] {
+            let src = tempfile::TempDir::new().unwrap();
+            let claude_dir = src.path().join("claude");
+            let (_, codex_dir) = absent_source_dirs(src.path());
+            seed_claude_source(&claude_dir);
+
+            let db_dir = tempfile::TempDir::new().unwrap();
+            let db_path = db_dir.path().join("recall.db");
+
+            let opts = indexer::IndexOptions {
+                force: false,
+                claude_dir: &claude_dir,
+                codex_dir: &codex_dir,
+            };
+            let outcome = index_and_report_with(&Some(db_path), &opts, || Err(reason))
+                .expect("a degraded index must succeed");
+
+            let note = outcome
+                .degraded_note
+                .unwrap_or_else(|| panic!("{reason:?} must carry a degraded note"));
+            assert!(
+                note.contains("unavailable"),
+                "{reason:?} must report unavailability (not a download hint), got: {note}"
+            );
+            assert!(
+                !note.to_lowercase().contains("download"),
+                "{reason:?} is not repaired by re-downloading, so the note must not \
+                 suggest it (that hint belongs to NotInstalled), got: {note}"
+            );
+            assert_eq!(outcome.embedded, 0, "{reason:?} skips embedding");
+            assert_eq!(outcome.failed_count, 0, "{reason:?} fails no batches");
+        }
+    }
+
+    // D6 (#130): Err(Disabled) yields the same IndexOutcome as a no-op success
+    // (degraded_note=None, all counters zero) — a caller-level opt-out is not a
+    // degradation, matching the search channel's contract (search_degraded_state
+    // returns (false, []) for Disabled). Production never constructs Disabled
+    // today (amici's loaders never return it and recall has no opt-out switch);
+    // this pin makes the collision explicit for whoever adds that switch.
+    #[test]
+    fn index_and_report_with_disabled_loader_is_indistinguishable_from_success() {
+        let src = tempfile::TempDir::new().unwrap();
+        let claude_dir = src.path().join("claude");
+        let (_, codex_dir) = absent_source_dirs(src.path());
+        seed_claude_source(&claude_dir);
+
+        let db_dir = tempfile::TempDir::new().unwrap();
+        let db_path = db_dir.path().join("recall.db");
+
+        let opts = indexer::IndexOptions {
+            force: false,
+            claude_dir: &claude_dir,
+            codex_dir: &codex_dir,
+        };
+        let outcome =
+            index_and_report_with(&Some(db_path), &opts, || Err(DegradedReason::Disabled))
+                .expect("a disabled-embedder index must succeed");
+
+        assert_eq!(
+            outcome.degraded_note, None,
+            "opt-out is not a degradation: no note is carried"
+        );
+        assert_eq!(outcome.embedded, 0, "a disabled embedder embeds nothing");
+        assert_eq!(
+            outcome.failed_count, 0,
+            "a disabled embedder fails no batches"
+        );
+        let envelope = index_command_output(&outcome);
+        assert!(
+            !envelope.degraded,
+            "the --json envelope reports a disabled embedder as non-degraded"
+        );
+    }
+
     // -- Phase 2 (D2, AC-4..7): index_command_output builds the --json envelope --
     //
     // index_command_output(&IndexOutcome) -> CommandOutput is the pure seam the Spec


### PR DESCRIPTION
## 概要と背景

#130 の残スライスのうち D3 (並行 hook の index 喪失) を修正し、D5/D6/TC-003/TC-004 を回帰テストとして固定する。v0.8.0/0.8.1 リリース後の実測 (38k chunks) で得た数値が判断の根拠。

## 変更内容

- **D3**: `busy_timeout` 5s → 30s (`src/db.rs`)。FTS index pass は全 tree で 3-12s の単一 write tx を保持するため (38k chunks 実測)、SessionEnd hook が同時多発すると後続が 5s timeout で SQLITE_BUSY となり、その回の index を失っていた (次回 self-heal はする)。30s は最長観測窓を吸収し、hook はバックグラウンド実行のため待ちはユーザーに見えない
- **TC-003**: steady-state re-index (hook の定常状態) で DB 内容が不変 (messages/qa_chunks/sessions/vec_chunks の COUNT) であることを pin
- **TC-004**: mtime 前進 append (live session の尻尾) が再 parse され、元メッセージと追記メッセージの両方が検索可能で、session が重複しないことを pin — self-heal の核心
- **D5**: index 文脈で BackendUnavailable/ProbeFailed が unavailability note を carry し、re-download を示唆しないことを pin (両 variant は amici `user_note` の同一アーム = 同一 equivalence class)
- **D6**: `Err(Disabled)` が no-op 成功と区別不能である現規約を pin (opt-out は非 degradation、search チャネルと同一規約。production は今日 Disabled を構成しない)

## 設計判断

- **D3 で bounded-batch commit (元の修正案) を採らない**: tx を分割すると `cleanup_orphans` が半端に scan された tree に対して orphan 判定する整合リスクが新たに生まれる。問題は lock 窓の長さだけで、timeout 引き上げで実害 (index 喪失) は消える。lock 窓自体の短縮は実害が再出現したら再評価
- **busy_timeout のテストは書かない**: 2 接続の write 競合 + 時間制御が必要で決定論的に書けず flaky 確定。根拠コメントを `db.rs` に記録
- **D5 の record_degraded 発火**: loader 単体テスト (`try_load_embedder_cached_records_degraded_non_install_failure`) で既カバー。production は `index_and_report` がその loader を silent reporter で配線済み (PR #134 で対称化済み = D5 の本体は解消済みだった)

## テスト方法

- `cargo nextest run --all-features`: 236 passed (新規 4 本含む)
- `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --check`: clean
- diff-cover (CI gate ローカル再現): **100%** (production 変更は db.rs の 1 行のみ)
- reviewer-coverage による独立レビュー: P0/P1 = 0、P2×3 + Low×1 の強化提案 (元メッセージ残存 assert / download 非示唆の negation / vec_chunks 監視 / assert メッセージ) は全て反映済み

## 関連

- Refs #130 (D3/D5/D6/TC-003/TC-004 のスライス。残: D4/D8 の一部、F21、CHX-002/004)
- 実測の経緯: #138 (pending scan fix)、PR #134 (D1/D2)
