### PR TITLE
score_and_sort: rank == 0.0 分岐は実DB検証で到達不能 — 削除/テストの cleanup

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -307,7 +307,6 @@ fn score_and_sort(
     let mut results: Vec<(SearchResult, f64)> = candidates
         .into_iter()
         .map(|(rank, result)| {
-            let recency_boost = hybrid::recency_decay(now_ms, result.session.timestamp);
             // bm25 rank is negative (lower = better), so the (1 + w*boost)
             // multiplier amplifies magnitude and recent sessions sort earlier
             // (ascending). Intentionally asymmetric with the hybrid path
@@ -315,6 +314,11 @@ fn score_and_sort(
             // exactly 0.0 would nullify the blend but is unreachable with
             // trigram FTS (#119: needs a trigram in exactly N/2 of all rows;
             // verified absent on the live index).
+            debug_assert!(
+                rank < 0.0,
+                "FTS bm25 rank must be negative; rank={rank} would nullify the recency blend or invert ordering"
+            );
+            let recency_boost = hybrid::recency_decay(now_ms, result.session.timestamp);
             let blended_rank = rank * (1.0 + RECENCY_BOOST_WEIGHT * recency_boost);
             (result, blended_rank)
         })
@@ -1093,7 +1097,8 @@ mod tests {
     #[test]
     fn test_score_and_sort_prefers_recent_on_equal_rank() {
         let now_ms = 1_750_000_000_000_i64;
-        let old_ts = now_ms - 90 * 24 * 60 * 60 * 1000; // ~3 half-lives back
+        // exactly 3 half-lives back (3 x RECENCY_HALF_LIFE_DAYS), decay = 0.125
+        let old_ts = now_ms - 90 * MS_PER_DAY;
         let candidates = vec![
             (-1.0, make_result("old", old_ts)),
             (-1.0, make_result("recent", now_ms)),
@@ -1101,6 +1106,21 @@ mod tests {
         let results = score_and_sort(candidates, now_ms, 10);
         assert_eq!(results[0].session.session_id, "recent");
         assert_eq!(results[1].session.session_id, "old");
+    }
+
+    // T-119b: a None-timestamp candidate gets recency_decay = 0.0, so the
+    // blend is a no-op and it sorts after an equal-rank dated candidate.
+    // None timestamps are production-reachable (sessions whose JSONL has no
+    // parseable ISO timestamp line are stored with a NULL timestamp).
+    #[test]
+    fn test_score_and_sort_sorts_none_timestamp_last_on_equal_rank() {
+        let now_ms = 1_750_000_000_000_i64;
+        let mut no_ts = make_result("no-ts", now_ms);
+        no_ts.session.timestamp = None;
+        let candidates = vec![(-1.0, no_ts), (-1.0, make_result("dated", now_ms))];
+        let results = score_and_sort(candidates, now_ms, 10);
+        assert_eq!(results[0].session.session_id, "dated");
+        assert_eq!(results[1].session.session_id, "no-ts");
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -308,11 +308,14 @@ fn score_and_sort(
         .into_iter()
         .map(|(rank, result)| {
             let recency_boost = hybrid::recency_decay(now_ms, result.session.timestamp);
-            let blended_rank = if rank == 0.0 {
-                -recency_boost
-            } else {
-                rank * (1.0 + RECENCY_BOOST_WEIGHT * recency_boost)
-            };
+            // bm25 rank is negative (lower = better), so the (1 + w*boost)
+            // multiplier amplifies magnitude and recent sessions sort earlier
+            // (ascending). Intentionally asymmetric with the hybrid path
+            // (apply_recency_boost: positive RRF scores, descending). A rank of
+            // exactly 0.0 would nullify the blend but is unreachable with
+            // trigram FTS (#119: needs a trigram in exactly N/2 of all rows;
+            // verified absent on the live index).
+            let blended_rank = rank * (1.0 + RECENCY_BOOST_WEIGHT * recency_boost);
             (result, blended_rank)
         })
         .collect();
@@ -1083,6 +1086,21 @@ mod tests {
             .collect();
         let results = score_and_sort(candidates, now_ms, 3);
         assert_eq!(results.len(), 3);
+    }
+
+    // T-119: the recency blend amplifies negative bm25 ranks, so equal-rank
+    // candidates sort recent-first under the ascending sort.
+    #[test]
+    fn test_score_and_sort_prefers_recent_on_equal_rank() {
+        let now_ms = 1_750_000_000_000_i64;
+        let old_ts = now_ms - 90 * 24 * 60 * 60 * 1000; // ~3 half-lives back
+        let candidates = vec![
+            (-1.0, make_result("old", old_ts)),
+            (-1.0, make_result("recent", now_ms)),
+        ];
+        let results = score_and_sort(candidates, now_ms, 10);
+        assert_eq!(results[0].session.session_id, "recent");
+        assert_eq!(results[1].session.session_id, "old");
     }
 
     #[test]


### PR DESCRIPTION
## What & Why

`score_and_sort` (FTS-only パス) の `rank == 0.0` 分岐は実 DB 検証で到達不能と確定済み (#119)。死んだ防御分岐は「bm25=0 がありうる」という誤った前提を読み手に植え付けるため削除し、hybrid パスとの recency blend 非対称が意図的であることをコメントで固定する。

## Changes

- `rank == 0.0` 分岐を削除し blend を一本化: bm25=0 ⟺ 単一 trigram が全 121,624 行のちょうど N/2 に出現、が成立条件だが該当 trigram は 0 個 (doc 分布は N/2 帯が空洞)。8715384 で防御的に後付けされた分岐で、初版 e5c7bb4 には存在しない
- 非対称の意図をコメント化: FTS-only は負の bm25 を昇順、hybrid (`apply_recency_boost`) は正の RRF を降順。同じ `(1 + w*boost)` 乗算で振る舞いが逆に見えるのは意図的
- T-119 追加: 同 rank 候補が recent-first になる blend 方向を固定 (既存 test_score_and_sort_respects_limit は limit のみ検証)

### Pre-merge audit 対応 (623ecab)

11 reviewer → challenger/verifier → integrator の audit パイプラインを通し、確定 findings の推奨修正 3 点を適用:

- `debug_assert!(rank < 0.0, ...)` を blend 直前に追加: 分岐削除で散文コメントのみになった「bm25 は負」不変条件を実行可能な前提条件として固定
- T-119 の `90 * 24 * 60 * 60 * 1000` リテラルを `90 * MS_PER_DAY` に置換し、コメントを「exactly 3 half-lives, decay = 0.125」と明示
- T-119b 追加: timestamp が None の行が同 rank で末尾に来ることを固定 (parser の earliest_ts は ISO timestamp 非検出時 None のままで production 到達可能)

## How to Test

1. `cargo test score_and_sort` → 3 passed (T-119 / T-119b 含む)
2. `cargo test` → 238 passed (unit 210 + cli_integration 28)
3. `cargo clippy --all-targets` → 警告なし

## Related

- Closes #119
