### PR TITLE
index_chunks: セッション単位の進捗表示を追加 (embed 側と対称化)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -449,7 +449,14 @@ pub(crate) struct ChunkStats {
 
 /// Chunks every un-chunked session inside a single transaction. `on_progress`
 /// receives `(done_sessions, total_sessions)` after each session — session
-/// units, unlike `embed_chunks` whose callback counts chunks.
+/// units, unlike `embed_chunks` whose callback counts chunks. Progress counts
+/// staged work, not durable state: the callback fires before the final commit,
+/// whereas `embed_chunks` commits each batch before firing.
+///
+/// # Panics
+///
+/// Propagates a panic from `on_progress`; the unwind drops the open
+/// transaction and rusqlite rolls back every staged chunk.
 pub(crate) fn index_chunks(
     conn: &mut Connection,
     on_progress: Option<&dyn Fn(usize, usize)>,
@@ -1075,6 +1082,34 @@ mod tests {
         // s2 has no messages (0 chunks) yet still counts toward done/total.
         assert_eq!(calls.into_inner().unwrap(), vec![(1, 2), (2, 2)]);
         assert_eq!(stats.chunks_created, 1);
+    }
+
+    #[test]
+    fn test_index_chunks_progress_callback_silent_when_all_chunked() {
+        let (_dir, mut conn) = setup_test_db();
+        conn.execute(
+            "INSERT INTO sessions VALUES ('s1', 'claude', '/f1', '/p', 'slug', 0, 0.0, NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, text) VALUES ('s1', 'user', 'hello')",
+            [],
+        )
+        .unwrap();
+        index_chunks(&mut conn, None).unwrap();
+
+        // Every session is chunked, so the empty early-return must not
+        // invoke the callback even when one is supplied.
+        let calls = Mutex::new(Vec::new());
+        let stats = index_chunks(
+            &mut conn,
+            Some(&|done, total| calls.lock().unwrap().push((done, total))),
+        )
+        .unwrap();
+
+        assert_eq!(stats.chunks_created, 0);
+        assert_eq!(calls.into_inner().unwrap(), Vec::<(usize, usize)>::new());
     }
 
     #[test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -447,7 +447,13 @@ pub(crate) struct ChunkStats {
     pub chunks_created: usize,
 }
 
-pub(crate) fn index_chunks(conn: &mut Connection) -> Result<ChunkStats> {
+/// Chunks every un-chunked session inside a single transaction. `on_progress`
+/// receives `(done_sessions, total_sessions)` after each session — session
+/// units, unlike `embed_chunks` whose callback counts chunks.
+pub(crate) fn index_chunks(
+    conn: &mut Connection,
+    on_progress: Option<&dyn Fn(usize, usize)>,
+) -> Result<ChunkStats> {
     let sessions: Vec<(String, Option<i64>)> = {
         let mut stmt = conn.prepare(
             "SELECT s.session_id, s.timestamp FROM sessions s \
@@ -465,9 +471,10 @@ pub(crate) fn index_chunks(conn: &mut Connection) -> Result<ChunkStats> {
 
     info!(count = sessions.len(), "Chunking sessions");
 
+    let total = sessions.len();
     let tx = conn.transaction()?;
     let mut chunks_created = 0;
-    for (session_id, timestamp) in &sessions {
+    for (done, (session_id, timestamp)) in sessions.iter().enumerate() {
         let messages = {
             let mut stmt = tx.prepare_cached(
                 "SELECT role, text FROM messages WHERE session_id = ? ORDER BY rowid",
@@ -496,6 +503,10 @@ pub(crate) fn index_chunks(conn: &mut Connection) -> Result<ChunkStats> {
             )?;
             chunks_created += 1;
         }
+
+        if let Some(cb) = &on_progress {
+            cb(done + 1, total);
+        }
     }
 
     tx.commit()?;
@@ -505,6 +516,7 @@ pub(crate) fn index_chunks(conn: &mut Connection) -> Result<ChunkStats> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
     use std::time::{Duration, SystemTime};
 
     use super::*;
@@ -578,7 +590,7 @@ mod tests {
         };
 
         index_from_dirs(&mut conn, &opts).unwrap();
-        index_chunks(&mut conn).unwrap();
+        index_chunks(&mut conn, None).unwrap();
         let counts = |conn: &Connection| -> (i64, i64, i64, i64) {
             let m = conn
                 .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
@@ -597,7 +609,7 @@ mod tests {
         let before = counts(&conn);
 
         let stats = index_from_dirs(&mut conn, &opts).unwrap();
-        index_chunks(&mut conn).unwrap();
+        index_chunks(&mut conn, None).unwrap();
 
         assert_eq!(stats.indexed, 0, "an unchanged tree re-parses nothing");
         assert_eq!(
@@ -789,7 +801,7 @@ mod tests {
         assert_eq!(stats.indexed, 1);
 
         // Populate qa_chunks + vec_chunks before force reindex
-        index_chunks(&mut conn).unwrap();
+        index_chunks(&mut conn, None).unwrap();
         let embedder = MockEmbedder::new();
         embed_recent_chunks(&mut conn, &embedder, 100, None).unwrap();
         let qa_before: i64 = conn
@@ -852,7 +864,7 @@ mod tests {
         assert_eq!(stats.total_sessions, 2);
 
         // Create chunks + embeddings for session2 before deleting the file
-        index_chunks(&mut conn).unwrap();
+        index_chunks(&mut conn, None).unwrap();
         let embedder = MockEmbedder::new();
         embed_recent_chunks(&mut conn, &embedder, 100, None).unwrap();
         let chunks_before: i64 = conn
@@ -1027,11 +1039,42 @@ mod tests {
         )
         .unwrap();
 
-        let stats1 = index_chunks(&mut conn).unwrap();
+        let stats1 = index_chunks(&mut conn, None).unwrap();
         assert_eq!(stats1.chunks_created, 1);
 
-        let stats2 = index_chunks(&mut conn).unwrap();
+        let stats2 = index_chunks(&mut conn, None).unwrap();
         assert_eq!(stats2.chunks_created, 0);
+    }
+
+    #[test]
+    fn test_index_chunks_progress_callback_counts_sessions() {
+        let (_dir, mut conn) = setup_test_db();
+        for (sid, file) in [("s1", "/f1"), ("s2", "/f2")] {
+            conn.execute(
+                "INSERT INTO sessions VALUES (?1, 'claude', ?2, '/p', 'slug', 0, 0.0, NULL)",
+                rusqlite::params![sid, file],
+            )
+            .unwrap();
+        }
+        for (role, text) in [("user", "hello"), ("assistant", "hi there")] {
+            conn.execute(
+                "INSERT INTO messages (session_id, role, text) VALUES ('s1', ?1, ?2)",
+                rusqlite::params![role, text],
+            )
+            .unwrap();
+        }
+
+        let calls = Mutex::new(Vec::new());
+        let stats = index_chunks(
+            &mut conn,
+            Some(&|done, total| calls.lock().unwrap().push((done, total))),
+        )
+        .unwrap();
+
+        // Progress advances per session processed, not per chunk created:
+        // s2 has no messages (0 chunks) yet still counts toward done/total.
+        assert_eq!(calls.into_inner().unwrap(), vec![(1, 2), (2, 2)]);
+        assert_eq!(stats.chunks_created, 1);
     }
 
     #[test]
@@ -1106,7 +1149,7 @@ mod tests {
             },
         )
         .unwrap();
-        index_chunks(&mut conn).unwrap();
+        index_chunks(&mut conn, None).unwrap();
 
         let chunk_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))
@@ -1159,7 +1202,7 @@ mod tests {
             )
             .unwrap();
         }
-        index_chunks(&mut conn).unwrap();
+        index_chunks(&mut conn, None).unwrap();
 
         let chunk_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,7 +375,10 @@ where
     sp.finish_with_detail(&main_msg, stats.parse_error_detail().as_deref());
 
     let sp = Spinner::new("Creating chunks...");
-    let chunk_stats = indexer::index_chunks(&mut conn)?;
+    let chunk_stats = indexer::index_chunks(
+        &mut conn,
+        Some(&|done, total| sp.set_message(&format!("Creating chunks... {done}/{total} sessions"))),
+    )?;
     if chunk_stats.chunks_created > 0 {
         sp.finish(&format!("Created {} chunks", chunk_stats.chunks_created));
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,10 +375,10 @@ where
     sp.finish_with_detail(&main_msg, stats.parse_error_detail().as_deref());
 
     let sp = Spinner::new("Creating chunks...");
-    let chunk_stats = indexer::index_chunks(
-        &mut conn,
-        Some(&|done, total| sp.set_message(&format!("Creating chunks... {done}/{total} sessions"))),
-    )?;
+    let on_progress = |done: usize, total: usize| {
+        sp.set_message(&format!("Creating chunks... {done}/{total} sessions"));
+    };
+    let chunk_stats = indexer::index_chunks(&mut conn, Some(&on_progress))?;
     if chunk_stats.chunks_created > 0 {
         sp.finish(&format!("Created {} chunks", chunk_stats.chunks_created));
     } else {


### PR DESCRIPTION
## What & Why

`index_chunks` は全未チャンク化セッションを単一トランザクションで処理するが進捗コールバックを持たず、`embed_chunks` 系 (`on_progress`) と非対称だった (#121)。初回 index は数千セッションの chunking で TTY でも無音になるため、embed 側と同じ進捗表示で対称化する。

## Changes

- `index_chunks` に `on_progress: Option<&dyn Fn(usize, usize)>` を追加 (embed_chunks と同型)。単位は処理済みセッション数 (chunk 数ではない)。単一トランザクションは維持 (バッチ tx 化は PURPOSE「正確性 > 速度」逆行で issue にて却下済み)
- 呼び出し元 spinner に "Creating chunks... N/M sessions" を配線。可視化は interactive (TTY) 実行のみ — Spinner の描画スレッドは非 TTY (SessionEnd hook 文脈) では起動しない
- テスト追加: コールバックが (1,2),(2,2) の exact 列で呼ばれ、0 chunk セッション (messages なし) でも done が前進することを固定

### Pre-merge audit 対応 (3f0ad3d)

11 reviewer → challenger/verifier → causation → integrator の full pipeline (trust 87、findings 11 → confirmed 3 / refuted 8):

- docstring に契約を明文化: progress は **staged-not-durable** (最終 commit 前に発火。embed_chunks は batch ごとに commit 後発火という意味論差を明記) + `# Panics` (callback panic は open tx を unwind し staged 全 chunk を rollback)
- テスト追加: 全 chunk 済み DB + `Some(cb)` で callback が 0 回である silence 契約を pin (empty early-return boundary)
- accept-as-is と裁定: per-session cadence の alloc churn (DB I/O が支配的で regression なし)、closure 2 箇所 (DRY 3+ gate 未満)、冗長 borrow (embed 側と同形式)

## How to Test

1. `cargo test test_index_chunks_progress` → 2 passed (counts_sessions / silent_when_all_chunked)
2. `cargo test` → 240 passed (unit 212 + cli_integration 28)
3. `cargo clippy --all-targets` → 警告なし

## Related

- Closes #121
