### PR TITLE
.gitignore の docs/ が tracked な docs/PURPOSE.md と矛盾し、新規 doc が silent ignore される

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .yomu/
 .claude/
 .playwright-cli/
-docs/
 target/
 workspace/
 


### PR DESCRIPTION
## What & Why

`.gitignore` の `docs/` 行を削除し、tracked な `docs/PURPOSE.md` との矛盾を解消する。`docs/` の全 ignore は永続 doc を持つ recall には不適切で、新規 doc が silent-ignore され `git add docs/<file>` が exit 1 で失敗していた。

## Changes

- `.gitignore` から `docs/` 行を削除 — tracked な `docs/PURPOSE.md` と矛盾し、新規 doc の silent-ignore / `git add` 失敗を招いていたため

## Scope

- **Not included**: 他リポジトリの `.gitignore` 横断見直し（永続 doc を track するリポジトリは `docs/` を全 ignore しない fleet 慣行の確認は別途）

## Design Decisions

- `docs/` 配下を個別 ignore せず行ごと削除 — 永続 doc を track するリポジトリは `docs/` を全 ignore しない fleet 慣行に合わせ、再発を防ぐ

## How to Test

1. `git switch fix/154-gitignore-docs`
2. `git check-ignore docs/PURPOSE.md` → 出力なし・exit 1（ignore されない）を確認
3. `touch docs/_scratch.md && git add docs/_scratch.md` → exit 0 で stage される（silent-ignore されない）。確認後 `git rm --cached docs/_scratch.md && rm docs/_scratch.md`

## Related

- Closes #154
