### PR TITLE
Cargo.toml に rurico/amici の rev lockstep コメントを追加する

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,15 @@ repository = "https://github.com/thkt/recall"
 test-support = ["rurico/test-support"]
 
 [dependencies]
+# amici pins its own rurico rev; a git source resolves to one rev across the
+# dependency graph, so the rurico rev below must match the one amici pins or
+# the build breaks on the rev conflict. When bumping amici, align rurico to it.
 amici = { git = "https://github.com/thkt/amici", rev = "5f4ee12" }
 anyhow = "1.0.102"
 bytemuck = "1"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 dirs = "6.0.0"
+# Keep in lockstep with the rurico rev amici pins (see the amici note above).
 rurico = { git = "https://github.com/thkt/rurico", rev = "adbe3a8" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
## 概要と背景

amici は rurico を内部で pin し、recall も rurico を直接 pin する。git source は依存グラフ内で 1 rev に解決されるため両 rev の一致が必須で、ズレると build が rev conflict で壊れる。この lockstep 制約が Cargo.toml に未記録で、次の bump 時に制約を知らず踏むリスクがあった。yomu と同型のコメントを追加して予防する。

## 変更点

- amici 行の上に lockstep 制約 3 行（git source は 1 rev 解決 / amici が pin する rurico rev と一致しないと build fail / bump は amici 先行で rurico を揃える）
- rurico 行の上に cross-ref 1 行（amici の注記を参照）

## スコープ

- 対象外: dev-dependencies 側（L28/L29）はコメントなし。同じ git source は同一 rev に解決され `[dependencies]` 側の注記が制約を説明済み。yomu も dev-deps は無印で同型。

## 設計判断

- yomu PR #313 と同型の文面・配置を採用。rev 番号（5f4ee12 / adbe3a8）も yomu と一致するため文面をそのまま流用し、fleet 全体で説明形式を揃える。

## テスト手順

1. `cargo metadata --no-deps --format-version 1` を実行
2. exit 0 でパース成功（コメントのみで依存解決・build に影響なし）

## 関連

- Closes #153