### PR TITLE
coverage filter の堅牢化: brace 検出の token-aware 化と fail-loud 化

### DIFF
--- a/.github/scripts/filter_lcov_cfg_test.py
+++ b/.github/scripts/filter_lcov_cfg_test.py
@@ -11,16 +11,84 @@ diff coverage gate.
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 
+def _scan_line(line: str, state):
+    """Count code-context braces in one line, carrying string state across lines.
+
+    `state` is None in code context, "str" inside a normal "..." string, or an
+    int n inside a raw string with n hashes (carried across lines so multi-line
+    strings are handled). Braces inside string literals, char literals, and line
+    comments are ignored so a stray `{` in `write!("{{")` or `'{'` does not
+    corrupt the cfg(test) range scan. Block comments (`/* */`) are intentionally
+    unhandled: no recall source uses them inside `#[cfg(test)]` items. A brace in
+    one is counted as code, so an unbalanced `/* { */` over-extends a range
+    exactly as the pre-refactor raw counter did -- never worse, but not fixed.
+    Returns (delta, state).
+    """
+    delta = 0
+    i = 0
+    n = len(line)
+    while i < n:
+        c = line[i]
+        if state == "str":
+            if c == "\\":
+                i += 2
+            elif c == '"':
+                state = None
+                i += 1
+            else:
+                i += 1
+            continue
+        if isinstance(state, int):  # raw string with `state` hashes
+            if c == '"' and line[i + 1 : i + 1 + state] == "#" * state:
+                i += 1 + state
+                state = None
+            else:
+                i += 1
+            continue
+        if c == '"':  # normal string opens
+            state = "str"
+            i += 1
+        elif c == "r" and i + 1 < n and line[i + 1] in '#"':  # raw string?
+            j = i + 1
+            while j < n and line[j] == "#":
+                j += 1
+            if j < n and line[j] == '"':
+                state = j - (i + 1)  # hash count (0 for r"...")
+                i = j + 1
+            else:
+                i += 1  # raw identifier r#ident, not a raw string
+        elif c == "'":
+            if i + 1 < n and line[i + 1] == "\\":  # escaped char '\n' '\u{7b}'
+                j = i + 3
+                while j < n and line[j] != "'":
+                    j += 1
+                i = j + 1
+            elif i + 2 < n and line[i + 2] == "'":  # simple char 'X' incl '{'
+                i += 3
+            else:  # lifetime 'a / 'static: treat ' as ordinary
+                i += 1
+        elif c == "/" and i + 1 < n and line[i + 1] == "/":  # line comment
+            break
+        elif c == "{":
+            delta += 1
+            i += 1
+        elif c == "}":
+            delta -= 1
+            i += 1
+        else:
+            i += 1
+    return delta, state
+
+
 def brace_delta(line: str) -> int:
-    # NOTE: counts raw `{`/`}` including those inside string literals, char
-    # literals, and comments. This miscounts lines like `write!(buf, "{{")`, but
-    # no current recall source triggers it (multi-line raw-string JSON braces in
-    # the tests are balanced and net to zero). A correct fix needs a Rust
-    # tokenizer; tracked as a followup. See test_filter_lcov_cfg_test.py xfails.
-    return line.count("{") - line.count("}")
+    # Single-line net brace count in code context (no carried state). Thin
+    # wrapper over the stateful core for callers that scan a line in isolation.
+    delta, _ = _scan_line(line, None)
+    return delta
 
 
 def cfg_test_ranges(path: Path) -> set[int]:
@@ -46,9 +114,11 @@ def cfg_test_ranges(path: Path) -> set[int]:
         balance = 0
         end_idx = item_idx
         saw_block = False
+        state = None
         while end_idx < len(lines):
-            balance += brace_delta(lines[end_idx])
-            if "{" in lines[end_idx]:
+            delta, state = _scan_line(lines[end_idx], state)
+            balance += delta
+            if balance > 0:
                 saw_block = True
             if saw_block and balance <= 0:
                 break
@@ -153,18 +223,71 @@ def render_record(record: list[str], ignored: set[int]) -> list[str]:
     return output
 
 
+def _is_under(path: Path, root: Path) -> bool:
+    try:
+        return path.resolve().is_relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+
+
+def _check_source_resolvable(source: Path, repo_root: Path) -> bool:
+    # Decide whether `source` should be scanned for cfg(test) ranges.
+    #   non-.rs          -> scan (cfg_test_ranges returns set() anyway).
+    #   .rs outside root -> skip WITHOUT reading. An external/registry dep cannot
+    #                       affect the gate (diff-cover scores only this repo's
+    #                       changed lines), and skipping avoids reading an
+    #                       out-of-tree path even when it exists (a traversed SF).
+    #   .rs under root,
+    #     missing        -> OPS-006: SF path resolution is broken and test code
+    #                       would leak into the gate. Fail loud.
+    if source.suffix != ".rs":
+        return True
+    if not _is_under(source, repo_root):
+        print(f"warning: skipping out-of-root source: {source}", file=sys.stderr)
+        return False
+    if not source.exists():
+        raise FileNotFoundError(
+            f"SF source under repo root does not exist: {source} (repo_root={repo_root}). "
+            "Path resolution is broken; test code would leak into the coverage gate."
+        )
+    return True
+
+
+def _validate_filtered(filtered: list[str], sf_count: int, input_path: Path) -> None:
+    # ENC-002: diff-cover treats an empty / record-less tracefile as 100%
+    # covered, so an over-aggressive filter that drops every record would
+    # silently disable the gate. Require at least one SF and one end_of_record
+    # per SF.
+    if sf_count == 0:
+        raise ValueError(
+            f"filtered lcov has no SF records; coverage input {input_path} "
+            "was empty or unparsable"
+        )
+    eor_count = filtered.count("end_of_record")
+    if eor_count != sf_count:
+        raise ValueError(
+            f"filtered lcov record mismatch for {input_path}: "
+            f"{sf_count} SF but {eor_count} end_of_record"
+        )
+
+
 def filter_lcov(input_path: Path, output_path: Path, repo_root: Path) -> None:
     filtered: list[str] = []
     record: list[str] = []
     ignored: set[int] = set()
+    sf_count = 0
 
     for line in input_path.read_text(encoding="utf-8").splitlines():
         if line.startswith("SF:"):
+            sf_count += 1
             record = [line]
             source = Path(line[3:])
             if not source.is_absolute():
                 source = repo_root / source
-            ignored = cfg_test_ranges(source)
+            if _check_source_resolvable(source, repo_root):
+                ignored = cfg_test_ranges(source)
+            else:
+                ignored = set()
             continue
 
         if line == "end_of_record":
@@ -178,6 +301,7 @@ def filter_lcov(input_path: Path, output_path: Path, repo_root: Path) -> None:
         else:
             filtered.append(line)
 
+    _validate_filtered(filtered, sf_count, input_path)
     output_path.write_text("\n".join(filtered) + "\n", encoding="utf-8")
 
 

--- a/.github/scripts/test_filter_lcov_cfg_test.py
+++ b/.github/scripts/test_filter_lcov_cfg_test.py
@@ -4,9 +4,9 @@ Run: python3 -m pytest .github/scripts/test_filter_lcov_cfg_test.py
 
 The filter sits between `cargo llvm-cov` and `diff-cover`, so a brace-counting
 bug that misclassifies production code as test code silently weakens the 95%
-gate. These tests pin the current raw-count behavior and document its known
-limitation (string-literal braces) as xfail until a Rust tokenizer replaces the
-heuristic.
+gate. These tests pin the token-aware brace scanner (string / char / line-comment
+and multi-line raw-string braces are excluded) and the fail-loud guards on
+unresolved SF paths and empty filtered output.
 """
 
 from __future__ import annotations
@@ -18,15 +18,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from filter_lcov_cfg_test import brace_delta, cfg_test_ranges  # noqa: E402
-
-# Known limitation: brace_delta counts raw `{`/`}` including those inside string
-# literals / char literals / comments. No current recall source triggers a wrong
-# coverage range (multi-line raw-string JSON braces are balanced), so a proper
-# fix (a Rust tokenizer) is deferred. These xfails document the gap honestly
-# without forcing a regex masking implementation that broke multi-line raw
-# strings in src/indexer.rs.
-_TOKENIZER_LIMITATION = "brace counting miscounts string-literal braces; needs a Rust tokenizer (followup)"
+from filter_lcov_cfg_test import (  # noqa: E402
+    brace_delta,
+    cfg_test_ranges,
+    filter_lcov,
+)
 
 
 def test_brace_delta_counts_structural_braces():
@@ -35,23 +31,20 @@ def test_brace_delta_counts_structural_braces():
     assert brace_delta("fn f() {}") == 0
 
 
-@pytest.mark.xfail(reason=_TOKENIZER_LIMITATION, strict=False)
 def test_brace_delta_ignores_braces_in_string_literals():
     assert brace_delta('    write!(buf, "{{")?;') == 0
     assert brace_delta('    let s = "}";') == 0
 
 
-@pytest.mark.xfail(reason=_TOKENIZER_LIMITATION, strict=False)
 def test_brace_delta_ignores_char_literal_and_line_comment_braces():
     assert brace_delta("    let c = '{';") == 0
     assert brace_delta("    foo(); // a trailing { brace") == 0
 
 
-@pytest.mark.xfail(reason=_TOKENIZER_LIMITATION, strict=False)
 def test_cfg_test_ranges_brace_in_string_does_not_swallow_following_production(tmp_path):
-    # Aspirational: an unbalanced brace in a test string literal should not
-    # extend the ignored range into the production fn that follows. Raw-count
-    # cannot do this; documented as the followup tokenizer fix.
+    # An unbalanced brace in a test string literal must not extend the ignored
+    # range into the production fn that follows. The token-aware scanner ignores
+    # the string-literal brace, so the range ends at the test module's close.
     src = tmp_path / "x.rs"
     src.write_text(
         "#[cfg(test)]\n"  # 1
@@ -115,3 +108,136 @@ def test_cfg_test_ranges_non_rs_file_returns_empty(tmp_path):
 
 def test_cfg_test_ranges_missing_file_returns_empty(tmp_path):
     assert cfg_test_ranges(tmp_path / "nonexistent.rs") == set()
+
+
+def test_brace_delta_lifetime_not_treated_as_char():
+    # 'a and 'static are lifetimes, not char literals; the scanner must not
+    # consume the following code as a char and must still count real braces.
+    assert brace_delta("fn f<'a>(x: &'a str) {") == 1
+    assert brace_delta("impl<'a> Foo<'a> {}") == 0
+
+
+def test_brace_delta_char_escape_with_brace_in_codepoint():
+    # '\u{7b}' is the codepoint escape for '{'; the brace lives inside the char
+    # escape and must not be counted, while a real trailing brace is.
+    assert brace_delta(r"    let c = '\u{7b}'; if x {") == 1
+    assert brace_delta(r"    if c == '\x1b' { f(); }") == 0
+
+
+def test_cfg_test_ranges_unbalanced_brace_in_multiline_raw_string(tmp_path):
+    # An unbalanced brace inside a multi-line raw string must not leak the
+    # ignored range into the production fn that follows (raw-string state is
+    # carried across lines).
+    src = tmp_path / "x.rs"
+    src.write_text(
+        "#[cfg(test)]\n"  # 1
+        "mod tests {\n"  # 2
+        "    fn t() {\n"  # 3
+        '        let s = r#"{{{ unbalanced\n'  # 4  raw string opens, stray {
+        '        still raw }"#;\n'  # 5  ...closes; braces were inside the raw string
+        "        assert!(s.len() > 0);\n"  # 6
+        "    }\n"  # 7
+        "}\n"  # 8
+        "pub fn prod() -> i32 { 1 }\n",  # 9  production AFTER
+        encoding="utf-8",
+    )
+    ranges = cfg_test_ranges(src)
+    assert {1, 2, 3, 4, 5, 6, 7, 8} <= ranges
+    assert 9 not in ranges
+
+
+def test_filter_lcov_raises_on_unresolved_repo_source(tmp_path):
+    # OPS-006: a `.rs` SF path under repo_root that does not exist is a path
+    # resolution bug; fail loud rather than silently under-filtering.
+    lcov = tmp_path / "in.info"
+    lcov.write_text("SF:src/ghost.rs\nDA:1,1\nend_of_record\n", encoding="utf-8")
+    with pytest.raises(FileNotFoundError):
+        filter_lcov(lcov, tmp_path / "out.info", tmp_path)
+
+
+def test_filter_lcov_warns_and_skips_external_source(tmp_path, capsys):
+    # OPS-006 / SEC: an absolute `.rs` outside repo_root (external dep) cannot
+    # affect the gate (diff-cover scores only this repo's changed lines); it is
+    # skipped without reading and the record is passed through unfiltered.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lcov = repo / "in.info"
+    lcov.write_text(
+        "SF:/nonexistent/external/dep.rs\nDA:1,1\nend_of_record\n", encoding="utf-8"
+    )
+    out = repo / "out.info"
+    filter_lcov(lcov, out, repo)
+    assert "skipping out-of-root source" in capsys.readouterr().err
+    text = out.read_text(encoding="utf-8")
+    assert "SF:/nonexistent/external/dep.rs" in text  # record preserved, not dropped
+    assert "DA:1,1" in text  # skip-not-drop: line kept unfiltered
+    assert text.count("end_of_record") == 1
+
+
+def test_filter_lcov_raises_on_empty_input(tmp_path):
+    # ENC-002: an input with no SF records would yield a trivially-passing
+    # filtered file; fail loud.
+    lcov = tmp_path / "in.info"
+    lcov.write_text("TN:\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        filter_lcov(lcov, tmp_path / "out.info", tmp_path)
+
+
+def test_filter_lcov_emits_one_end_of_record_per_sf(tmp_path):
+    # ENC-002 well-formedness: one end_of_record per SF, production lines kept.
+    (tmp_path / "real.rs").write_text(
+        "pub fn f() -> i32 {\n    1\n}\n", encoding="utf-8"
+    )
+    lcov = tmp_path / "in.info"
+    lcov.write_text(
+        "SF:real.rs\nDA:1,1\nDA:2,1\nDA:3,1\nend_of_record\n", encoding="utf-8"
+    )
+    out = tmp_path / "out.info"
+    filter_lcov(lcov, out, tmp_path)
+    text = out.read_text(encoding="utf-8")
+    assert text.count("end_of_record") == 1
+    assert "SF:real.rs" in text
+    assert "DA:1,1" in text  # production line retained
+
+
+def test_filter_lcov_skips_existing_out_of_root_source(tmp_path, capsys):
+    # SEC: an EXISTING `.rs` resolved outside repo_root (e.g. a traversed SF
+    # path) is skipped without reading. The pre-fix code read it because
+    # _is_under was consulted only on the missing-file branch.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.rs"
+    secret.write_text("#[cfg(test)]\nmod tests {\n}\n", encoding="utf-8")
+    lcov = repo / "in.info"
+    lcov.write_text(f"SF:{secret}\nDA:1,1\nend_of_record\n", encoding="utf-8")
+    out = repo / "out.info"
+    filter_lcov(lcov, out, repo)
+    assert "skipping out-of-root source" in capsys.readouterr().err
+    # record passes through unfiltered (file was not read for cfg(test) ranges)
+    assert "DA:1,1" in out.read_text(encoding="utf-8")
+
+
+def test_filter_lcov_raises_on_sf_eor_mismatch(tmp_path):
+    # ENC-002 mismatch branch: an SF record with no end_of_record (truncated
+    # input) yields sf_count=1 but eor_count=0; the guard must fire (distinct
+    # from the empty-input branch).
+    (tmp_path / "real.rs").write_text("pub fn f() -> i32 { 1 }\n", encoding="utf-8")
+    lcov = tmp_path / "in.info"
+    lcov.write_text("SF:real.rs\nDA:1,1\n", encoding="utf-8")  # no end_of_record
+    with pytest.raises(ValueError):
+        filter_lcov(lcov, tmp_path / "out.info", tmp_path)
+
+
+def test_brace_delta_byte_strings_ignore_braces():
+    # Byte string b"{" and raw byte string br#"}"# keep their brace inside the
+    # string; the scanner consumes `b` as ordinary then enters string state.
+    assert brace_delta('    let b = b"{"; foo() {') == 1
+    assert brace_delta('    let r = br#"}"#; bar() }') == -1
+
+
+def test_brace_delta_escaped_quote_char():
+    # '\'' is an escaped-single-quote char literal; the scanner must skip it and
+    # still count a real trailing brace.
+    assert brace_delta(r"    let q = '\''; baz() {") == 1


### PR DESCRIPTION
## 概要と背景

cfg(test) coverage filter は生 brace カウントで、文字列/char/コメント内の brace を誤計上していた（#123 audit RC-3）。dormant（現ソースは balanced で実害なし）だが、token-aware 化 + fail-loud ガード追加で堅牢化する。

## 変更点

- token-aware lexer（`_scan_line`、行またぎ字句状態）: 文字列/raw string/char/lifetime/行コメント内の brace を除外。block comment は src 不在で省略。`brace_delta` は単一引数ラッパーで後方互換。
- 空出力ガード（ENC-002）: SF 数 == end_of_record 数 > 0 を検証し、空 filtered が trivial pass しないようにする。
- SF 解決 fail-loud（OPS-006）: repo_root 配下 .rs 非存在で raise / 外部パスは read せず skip（traversed SF の out-of-tree read 防止）。エラーに repo_root/input_path を含める。

## スコープ

- 対象外: pre-existing（`parse_*` の silent-default / EOF-orphan flush / `render_record` の FN/BRDA coverage）。follow-up issue 候補。

## 設計判断

- AC は「Rust tokenizer ベース or rustfmt 正規化前提」だが、第 3 案 = dependency-free な Python 手書き scanner を採用（Python CI スクリプトに Rust toolchain 依存を持ち込まない + 回帰検証済み）。意図的逸脱。
- block comment 省略: src の cfg(test) に /* */ ゼロ。balanced input で raw-count と一致（pre-refactor より悪化させない）。
- /audit 実施（10 reviewer → critic-audit 反証 → critic-evidence 検証）: confirmed high-severity bug 0。SEC-002（unbounded loop 疑い）は線形 O(L) と実証され verified false positive。SEC-001（外部 .rs read）は exists でも skip に修正（実 CI では out-of-root 不在で no-op の defensive hardening）。pre-existing は別 issue へ deferred。

## テスト

1. `python3 -m pytest .github/scripts/test_filter_lcov_cfg_test.py` を実行
2. 19 passed（xfail 3 解消 + lifetime/codepoint escape/multiline raw/byte string/escaped quote/out-of-root skip/sf-eor mismatch）
3. 実 lcov.info で旧 vs 新フィルタ byte-identical（回帰なし）

## 関連

- Closes #124