### PR TITLE
coverage filter の残存 hardening: malformed record の fail-loud 化 + EOF-orphan + テスト網羅

### DIFF
--- a/.github/scripts/filter_lcov_cfg_test.py
+++ b/.github/scripts/filter_lcov_cfg_test.py
@@ -132,20 +132,28 @@ def cfg_test_ranges(path: Path) -> set[int]:
     return ignored
 
 
-def parse_line_number(record: str) -> int | None:
+# The lcov record parsers below are tightly coupled to cargo llvm-cov's line
+# format (DA:<line>,<hit>  FN:<line>,<name>  FNDA:<count>,<name>). A parse failure
+# means that format contract is violated (tool upgrade, truncation, corruption),
+# so the filter's output can no longer be trusted. Fail loud rather than default
+# silently: a None/0 default would skew the gate in an unverifiable direction (a
+# dropped line number leaves test code in; a defaulted hit count marks a covered
+# line uncovered). This differs from ENC-002/OPS-006, which guard against
+# gate-weakening specifically; here the contract itself is the invariant.
+def parse_line_number(record: str) -> int:
     try:
         return int(record.split(":", 1)[1].split(",", 1)[0])
-    except (IndexError, ValueError):
-        return None
+    except (IndexError, ValueError) as e:
+        raise ValueError(f"malformed lcov record: {record!r}") from e
 
 
-def parse_fn(record: str) -> tuple[int | None, str]:
+def parse_fn(record: str) -> tuple[int, str]:
     try:
         payload = record.split(":", 1)[1]
         line, name = payload.split(",", 1)
         return int(line), name
-    except (IndexError, ValueError):
-        return None, ""
+    except (IndexError, ValueError) as e:
+        raise ValueError(f"malformed lcov FN record: {record!r}") from e
 
 
 def parse_fnda(record: str) -> tuple[int, str]:
@@ -153,8 +161,8 @@ def parse_fnda(record: str) -> tuple[int, str]:
         payload = record.split(":", 1)[1]
         count, name = payload.split(",", 1)
         return int(count), name
-    except (IndexError, ValueError):
-        return 0, ""
+    except (IndexError, ValueError) as e:
+        raise ValueError(f"malformed lcov FNDA record: {record!r}") from e
 
 
 def render_record(record: list[str], ignored: set[int]) -> list[str]:
@@ -174,8 +182,8 @@ def render_record(record: list[str], ignored: set[int]) -> list[str]:
             line_count += 1
             try:
                 hit_count = int(entry.split(",", 2)[1])
-            except (IndexError, ValueError):
-                hit_count = 0
+            except (IndexError, ValueError) as e:
+                raise ValueError(f"malformed lcov DA record: {entry!r}") from e
             if hit_count > 0:
                 line_hit += 1
             output.append(entry)
@@ -257,7 +265,10 @@ def _validate_filtered(filtered: list[str], sf_count: int, input_path: Path) -> 
     # ENC-002: diff-cover treats an empty / record-less tracefile as 100%
     # covered, so an over-aggressive filter that drops every record would
     # silently disable the gate. Require at least one SF and one end_of_record
-    # per SF.
+    # per SF. The mismatch branch is defense-in-depth: it backstops the invariant
+    # that the filtered output carries exactly one end_of_record per SF, catching
+    # any upstream record-accounting bug regardless of cause (the orphan check
+    # above already handles a truncated trailing record).
     if sf_count == 0:
         raise ValueError(
             f"filtered lcov has no SF records; coverage input {input_path} "
@@ -301,6 +312,10 @@ def filter_lcov(input_path: Path, output_path: Path, repo_root: Path) -> None:
         else:
             filtered.append(line)
 
+    if record:
+        raise ValueError(
+            f"truncated lcov: SF record not terminated by end_of_record in {input_path}"
+        )
     _validate_filtered(filtered, sf_count, input_path)
     output_path.write_text("\n".join(filtered) + "\n", encoding="utf-8")
 

--- a/.github/scripts/test_filter_lcov_cfg_test.py
+++ b/.github/scripts/test_filter_lcov_cfg_test.py
@@ -219,14 +219,32 @@ def test_filter_lcov_skips_existing_out_of_root_source(tmp_path, capsys):
     assert "DA:1,1" in out.read_text(encoding="utf-8")
 
 
-def test_filter_lcov_raises_on_sf_eor_mismatch(tmp_path):
-    # ENC-002 mismatch branch: an SF record with no end_of_record (truncated
-    # input) yields sf_count=1 but eor_count=0; the guard must fire (distinct
-    # from the empty-input branch).
+def test_filter_lcov_raises_on_orphan_record(tmp_path):
+    # Item 2 (EOF-orphan): an SF record with no terminating end_of_record
+    # (truncated input) leaves a non-empty record after the loop. The explicit
+    # orphan check fires -- earlier and with a clearer message than _validate's
+    # SF/end_of_record mismatch guard (which now only backs render_record's
+    # one-end_of_record-per-SF invariant). The match pins the orphan branch.
     (tmp_path / "real.rs").write_text("pub fn f() -> i32 { 1 }\n", encoding="utf-8")
     lcov = tmp_path / "in.info"
     lcov.write_text("SF:real.rs\nDA:1,1\n", encoding="utf-8")  # no end_of_record
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="not terminated by end_of_record"):
+        filter_lcov(lcov, tmp_path / "out.info", tmp_path)
+
+
+def test_filter_lcov_raises_on_mid_stream_orphan(tmp_path):
+    # _validate defense-in-depth (reachable): a record lacking end_of_record
+    # before the next SF (mid-stream orphan, not a trailing truncation) is missed
+    # by the orphan check -- the new SF resets record -- but trips _validate's
+    # SF / end_of_record count mismatch (2 SF, 1 end_of_record). Pins the backstop
+    # branch as reachable, refuting a "dead code" reading.
+    (tmp_path / "a.rs").write_text("pub fn a() -> i32 { 1 }\n", encoding="utf-8")
+    (tmp_path / "b.rs").write_text("pub fn b() -> i32 { 1 }\n", encoding="utf-8")
+    lcov = tmp_path / "in.info"
+    lcov.write_text(
+        "SF:a.rs\nDA:1,1\nSF:b.rs\nDA:1,1\nend_of_record\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="record mismatch"):
         filter_lcov(lcov, tmp_path / "out.info", tmp_path)
 
 
@@ -241,3 +259,111 @@ def test_brace_delta_escaped_quote_char():
     # '\'' is an escaped-single-quote char literal; the scanner must skip it and
     # still count a real trailing brace.
     assert brace_delta(r"    let q = '\''; baz() {") == 1
+
+
+def _cfg_test_src_with_ignored_line5(tmp_path: Path) -> Path:
+    # A source whose cfg(test) block (lines 3-6) makes line 5 an ignored line,
+    # while line 1 is production. Shared by the render_record FN/BRDA tests.
+    src = tmp_path / "real.rs"
+    src.write_text(
+        "pub fn prod() -> i32 { 1 }\n"  # 1 production
+        "\n"  # 2
+        "#[cfg(test)]\n"  # 3
+        "mod tests {\n"  # 4
+        "    fn t() {}\n"  # 5 ignored
+        "}\n",  # 6
+        encoding="utf-8",
+    )
+    return src
+
+
+def test_render_record_drops_fn_and_fnda_for_ignored_function(tmp_path):
+    # render_record FN/FNDA path: a FN declared on an ignored (cfg(test)) line is
+    # dropped and its name recorded in skipped_functions, so the matching FNDA is
+    # also dropped. FNF/FNH reflect only the surviving production function.
+    _cfg_test_src_with_ignored_line5(tmp_path)
+    lcov = tmp_path / "in.info"
+    lcov.write_text(
+        "SF:real.rs\n"
+        "FN:1,prod\n"
+        "FN:5,t\n"  # line 5 ignored -> recorded in skipped_functions
+        "FNDA:3,prod\n"
+        "FNDA:0,t\n"  # name in skipped_functions -> dropped
+        "DA:1,3\n"
+        "DA:5,0\n"  # ignored line -> dropped
+        "end_of_record\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.info"
+    filter_lcov(lcov, out, tmp_path)
+    text = out.read_text(encoding="utf-8")
+    assert "FN:1,prod" in text and "FNDA:3,prod" in text
+    assert "FN:5,t" not in text  # ignored-line FN dropped
+    assert "FNDA:0,t" not in text  # FNDA for a skipped function dropped
+    assert "FNF:1" in text and "FNH:1" in text  # one production fn, hit
+    assert "DA:5,0" not in text  # ignored DA dropped
+
+
+def test_render_record_branch_coverage_taken_and_ignored(tmp_path):
+    # render_record BRDA path: taken "-"/"0" is not a hit, any other value is; a
+    # BRDA on an ignored line is dropped. BRF/BRH count only surviving branches.
+    _cfg_test_src_with_ignored_line5(tmp_path)
+    lcov = tmp_path / "in.info"
+    lcov.write_text(
+        "SF:real.rs\n"
+        "DA:1,3\n"
+        "BRDA:1,0,0,3\n"  # taken 3 -> hit
+        "BRDA:1,0,1,0\n"  # taken 0 -> not hit
+        "BRDA:1,0,2,-\n"  # taken - -> not hit
+        "BRDA:5,0,0,1\n"  # line 5 ignored -> dropped
+        "end_of_record\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.info"
+    filter_lcov(lcov, out, tmp_path)
+    text = out.read_text(encoding="utf-8")
+    assert "BRDA:1,0,0,3" in text and "BRDA:1,0,1,0" in text and "BRDA:1,0,2,-" in text
+    assert "BRDA:5,0,0,1" not in text  # ignored-line branch dropped
+    assert "BRF:3" in text  # three surviving branches on line 1
+    assert "BRH:1" in text  # only the taken=3 branch is a hit
+
+
+def test_filter_lcov_raises_on_malformed_da_line_number(tmp_path):
+    # Item 1 (format-contract): a DA record whose line field is non-numeric means
+    # the cargo llvm-cov format assumption is violated; fail loud instead of
+    # silently passing the record through with a None line number.
+    (tmp_path / "real.rs").write_text("pub fn f() -> i32 { 1 }\n", encoding="utf-8")
+    lcov = tmp_path / "in.info"
+    lcov.write_text("SF:real.rs\nDA:abc,1\nend_of_record\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="malformed lcov record"):
+        filter_lcov(lcov, tmp_path / "out.info", tmp_path)
+
+
+def test_filter_lcov_raises_on_malformed_fn_line_number(tmp_path):
+    # Item 1: a FN record with a non-numeric line field is a format violation.
+    (tmp_path / "real.rs").write_text("pub fn f() -> i32 { 1 }\n", encoding="utf-8")
+    lcov = tmp_path / "in.info"
+    lcov.write_text("SF:real.rs\nFN:xyz,f\nDA:1,1\nend_of_record\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="malformed lcov FN record"):
+        filter_lcov(lcov, tmp_path / "out.info", tmp_path)
+
+
+def test_filter_lcov_raises_on_malformed_fnda_count(tmp_path):
+    # Item 1: a FNDA record with a non-numeric hit count is a format violation.
+    (tmp_path / "real.rs").write_text("pub fn f() -> i32 { 1 }\n", encoding="utf-8")
+    lcov = tmp_path / "in.info"
+    lcov.write_text(
+        "SF:real.rs\nFN:1,f\nFNDA:foo,f\nDA:1,1\nend_of_record\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="malformed lcov FNDA record"):
+        filter_lcov(lcov, tmp_path / "out.info", tmp_path)
+
+
+def test_filter_lcov_raises_on_malformed_da_hit_count(tmp_path):
+    # Item 1: a DA record with a non-numeric hit count (second field) is a format
+    # violation; render_record must fail loud rather than default the count to 0.
+    (tmp_path / "real.rs").write_text("pub fn f() -> i32 { 1 }\n", encoding="utf-8")
+    lcov = tmp_path / "in.info"
+    lcov.write_text("SF:real.rs\nDA:1,bar\nend_of_record\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="malformed lcov DA record"):
+        filter_lcov(lcov, tmp_path / "out.info", tmp_path)


### PR DESCRIPTION
## 概要と背景

#124 (PR #158) の audit が token-aware 化スコープ外で検出した pre-existing な堅牢性ギャップ 3 点。`.github/scripts/filter_lcov_cfg_test.py` は diff-cover 前に cfg(test) 範囲を除去する coverage gate filter。dormant（cargo llvm-cov 出力が well-formed なため未顕在）だが、入力が崩れた際に silent に gate を弱める経路を塞ぐ。

## 変更点

- silent-default パース fail-loud 化: `parse_line_number`/`parse_fn`/`parse_fnda` + `render_record` の DA hit-count、broad-except `(IndexError, ValueError)` が None/0 を返し malformed record を無警告素通りさせていた → raise 化。戻り型も `int | None` → `int` に flip（caller は `None not in ignored` 依存で dead code なし）。
- EOF-orphan 明示 raise: `filter_lcov` ループ後に未終端 record（末尾に `end_of_record` を欠く SF）を検出。`_validate` の SF/end_of_record mismatch は defense-in-depth へ降格。
- render_record テスト: FN/FNDA の skipped-function path と BRDA branch-coverage path を exercise（#158 は DA path のみ）。挙動変更なし。

## 設計判断

- fail-loud の理由は format-contract violation: パーサーは cargo llvm-cov の line format に密結合し、parse 失敗 = その前提が破れた（tool upgrade / truncation / corruption）= 出力が信頼できない。ENC-002/OPS-006（gate 弱体化を防ぐ）とは別軸で、ここは contract 自体が invariant。
- orphan の明示 check は `_validate` の間接 mismatch より「早い失敗 + 具体的メッセージ + コード意図の明確化」で earn。mismatch branch は「SF あたり 1 つの end_of_record」invariant の defense-in-depth として保持（mid-stream orphan で到達可能なことをテストで pin）。

## /audit 結果

10 reviewer fan-out → 実コードベース検証。**confirmed bug 0、#159 は as-is で shippable**。
- in-scope cleanup を反映: malformed テストに `match=`（raise site 区別、`_validate` の ValueError と取り違え防止）、mid-stream orphan テスト（`_validate` mismatch branch を pin）、項目2 コメントを invariant ベース化。
- follow-up issue へ defer: BRDA の `taken` fail-loud 化（#158 由来・parse_* 非経由）、parse エラーへの input_path/SF context 付与。
- 注記: reviewer 2 体が実在しないファイルを捏造する幻覚を起こしたため棄却。load-bearing findings（mid-stream orphan / BRDA taken）は直接実行で検証（challenger/verifier は同一幻覚リスクのため省略）。

## テスト

1. `python3 -m pytest .github/scripts/test_filter_lcov_cfg_test.py` を実行
2. 26 passed（既存 19 + malformed fail-loud 4〔各 `match=` で raise site pin〕 + render_record FN/FNDA・BRDA 2 + mid-stream orphan 1。orphan は既存テストを repoint）
3. 実 `lcov.info`（7371 行、同一 pinned cargo-llvm-cov）で旧 vs 新フィルタ byte-identical（filtered 3331 行）。新フィルタも well-formed 入力で exit 0 = except→raise は no-op、回帰なし。CI 等価（pytest → filter → diff-cover の入力が同一）。

## 関連

- Closes #159
- Follow-up to #124 (PR #158)
