### PR TITLE
fix: check cached model artifacts in no-database status branch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -684,6 +684,9 @@ fn run_show(session_id: &str, verbose: bool, db_path: &Option<PathBuf>) -> Resul
 
 fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<CommandOutput> {
     let path = resolve_db_path(db_path)?;
+    let model_ok = cached_artifacts(ModelId::DEFAULT)
+        .map(|opt| opt.is_some())
+        .unwrap_or(false);
     if !path.exists() {
         cli_info(&format!("database not found at {}", path.display()));
         cli_info("run `recall index` to create the index.");
@@ -693,7 +696,7 @@ fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<CommandOutput>
                 "sessions": 0,
                 "qa_chunks": 0,
                 "embedded": 0,
-                "model_ready": false,
+                "model_ready": model_ok,
             }),
         ));
     }
@@ -703,10 +706,6 @@ fn run_status(verbose: bool, db_path: &Option<PathBuf>) -> Result<CommandOutput>
     let sessions: i64 = conn.query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))?;
     let chunks: i64 = conn.query_row("SELECT COUNT(*) FROM qa_chunks", [], |r| r.get(0))?;
     let embedded: i64 = conn.query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))?;
-
-    let model_ok = cached_artifacts(ModelId::DEFAULT)
-        .map(|opt| opt.is_some())
-        .unwrap_or(false);
 
     // Writes to an in-memory Vec are infallible, so the io::Result is discarded.
     let mut buf = Vec::new();

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -456,8 +456,9 @@ fn rebuild_json_emits_structured_embed_summary() {
 }
 
 // T-CLI019: `status --json` against a never-created index reports zero counters
-// with model_ready:false as a success envelope, exit 0 — the no-database branch
-// of run_status. Pairs with T-CLI013, which runs `index` first (the live path).
+// with model_ready reflecting cached artifact state (false in test environment
+// since no artifacts exist) — the no-database branch of run_status.
+// Pairs with T-CLI013, which runs `index` first (the live path).
 #[test]
 fn status_json_without_index_reports_zero_counts() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
Closes #166

Summary: recall status --json reported model_ready: false whenever the database file did not exist, without checking whether cached model artifacts were already installed.

Changes:
- src/main.rs: Move cached_artifacts check above no-database branch so both status paths report actual model state
- tests/cli_integration.rs: Update test comment to reflect new behavior

Verification: whitespace clean, logic trace-through confirmed. Full cargo build requires cmake + Metal SDK (macOS), not available on Windows CI runner.